### PR TITLE
[NDD-405] Question에 index 추가 및 Workbook내에서 index순으로 조회&인덱스 벌크업데이트 기능 구현( 3/2 )

### DIFF
--- a/src/constant/constant.ts
+++ b/src/constant/constant.ts
@@ -18,6 +18,10 @@ export const companies = [
 ];
 export const DEFAULT_THUMBNAIL = process.env.DEFAULT_THUMBNAIL;
 
+export const OK = 200;
+export const CREATED = 201;
+export const NO_CONTENT = 204;
+
 export const BAD_REQUEST = 400;
 export const UNAUTHORIZED = 401;
 export const FORBIDDEN = 403;

--- a/src/question/controller/question.controller.spec.ts
+++ b/src/question/controller/question.controller.spec.ts
@@ -407,6 +407,63 @@ describe('QuestionController 통합테스트', () => {
         .expect(200)
         .then(() => {});
     });
+
+    it('로그인을 하지 않으면 401에러를 반환한다.', async () => {
+      //given
+      await memberRepository.save(memberFixture);
+      await categoryRepository.save(categoryFixtureWithId);
+      const workbook = await workbookRepository.save(workbookFixture);
+      const ids = [];
+      for (let index = 1; index <= 5; index++) {
+        ids.push(
+          (
+            await questionRepository.save(
+              Question.of(workbook, null, `tester${index}`),
+            )
+          ).id,
+        );
+      }
+
+      ids.push(ids.shift());
+      ids.push(ids.shift());
+      //when&then
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .patch('/api/question/index')
+        .send(new UpdateIndexInWorkbookRequest(workbook.id, ids))
+        .expect(401)
+        .then(() => {});
+    });
+
+    it('나의 문제집에 질문 순서를 바꾸면 성공적으로 인덱스를 수정한다.', async () => {
+      //given
+      await memberRepository.save(memberFixture);
+      await categoryRepository.save(categoryFixtureWithId);
+      const workbook = await workbookRepository.save(workbookFixture);
+      const ids = [];
+      for (let index = 1; index <= 5; index++) {
+        ids.push(
+          (
+            await questionRepository.save(
+              Question.of(workbook, null, `tester${index}`),
+            )
+          ).id,
+        );
+      }
+
+      ids.push(ids.shift());
+      ids.push(ids.shift());
+      //when&then
+      const agent = request.agent(app.getHttpServer());
+      await agent
+        .patch('/api/question/index')
+        .set('Cookie', [
+          `accessToken=${await authService.login(memberFixturesOAuthRequest)}`,
+        ])
+        .send(new UpdateIndexInWorkbookRequest(workbook.id, ids))
+        .expect(200)
+        .then(() => {});
+    });
   });
 
   afterEach(async () => {

--- a/src/question/controller/question.controller.spec.ts
+++ b/src/question/controller/question.controller.spec.ts
@@ -39,6 +39,7 @@ import { CategoryModule } from '../../category/category.module';
 import { categoryFixtureWithId } from '../../category/fixture/category.fixture';
 import { CopyQuestionRequest } from '../dto/copyQuestionRequest';
 import { UpdateIndexInWorkbookRequest } from '../dto/updateIndexInWorkbookRequest';
+import { FORBIDDEN, OK, UNAUTHORIZED } from 'src/constant/constant';
 
 describe('QuestionController', () => {
   let controller: QuestionController;
@@ -404,7 +405,7 @@ describe('QuestionController 통합테스트', () => {
           `accessToken=${await authService.login(memberFixturesOAuthRequest)}`,
         ])
         .send(new UpdateIndexInWorkbookRequest(workbook.id, ids))
-        .expect(200)
+        .expect(OK)
         .then(() => {});
     });
 
@@ -431,11 +432,11 @@ describe('QuestionController 통합테스트', () => {
       await agent
         .patch('/api/question/index')
         .send(new UpdateIndexInWorkbookRequest(workbook.id, ids))
-        .expect(401)
+        .expect(UNAUTHORIZED)
         .then(() => {});
     });
 
-    it('나의 문제집에 질문 순서를 바꾸면 성공적으로 인덱스를 수정한다.', async () => {
+    it('다른 사람의 인덱스를 수정하려하면 403에러를 반환한다.', async () => {
       //given
       await memberRepository.save(memberFixture);
       await categoryRepository.save(categoryFixtureWithId);
@@ -458,10 +459,10 @@ describe('QuestionController 통합테스트', () => {
       await agent
         .patch('/api/question/index')
         .set('Cookie', [
-          `accessToken=${await authService.login(memberFixturesOAuthRequest)}`,
+          `accessToken=${await authService.login(oauthRequestFixture)}`,
         ])
         .send(new UpdateIndexInWorkbookRequest(workbook.id, ids))
-        .expect(200)
+        .expect(FORBIDDEN)
         .then(() => {});
     });
   });

--- a/src/question/controller/question.controller.spec.ts
+++ b/src/question/controller/question.controller.spec.ts
@@ -438,9 +438,12 @@ describe('QuestionController 통합테스트', () => {
 
     it('다른 사람의 인덱스를 수정하려하면 403에러를 반환한다.', async () => {
       //given
-      await memberRepository.save(memberFixture);
-      await categoryRepository.save(categoryFixtureWithId);
-      const workbook = await workbookRepository.save(workbookFixture);
+      const token = await authService.login(memberFixturesOAuthRequest);
+      await memberRepository.save(otherMemberFixture);
+      const workbook = await workbookRepository.save(otherWorkbookFixture);
+      const question = await questionRepository.save(
+        Question.of(workbook, null, 'tester'),
+      );
       const ids = [];
       for (let index = 1; index <= 5; index++) {
         ids.push(
@@ -458,9 +461,7 @@ describe('QuestionController 통합테스트', () => {
       const agent = request.agent(app.getHttpServer());
       await agent
         .patch('/api/question/index')
-        .set('Cookie', [
-          `accessToken=${await authService.login(oauthRequestFixture)}`,
-        ])
+        .set('Cookie', [`accessToken=${token}`])
         .send(new UpdateIndexInWorkbookRequest(workbook.id, ids))
         .expect(FORBIDDEN)
         .then(() => {});

--- a/src/question/controller/question.controller.ts
+++ b/src/question/controller/question.controller.ts
@@ -107,6 +107,8 @@ export class QuestionController {
   }
 
   @Patch('/index')
+  @UseGuards(TokenHardGuard)
+  @ApiCookieAuth()
   @ApiOperation({
     summary: '질문들의 인덱스 조정',
   })

--- a/src/question/controller/question.controller.ts
+++ b/src/question/controller/question.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   Param,
+  Patch,
   Post,
   Req,
   Res,
@@ -25,6 +26,17 @@ import { Member } from '../../member/entity/member';
 import { CopyQuestionRequest } from '../dto/copyQuestionRequest';
 import { WorkbookIdResponse } from '../../workbook/dto/workbookIdResponse';
 import { TokenHardGuard } from 'src/token/guard/token.hard.guard';
+import {
+  BAD_REQUEST,
+  FORBIDDEN,
+  GONE,
+  INTERNAL_SERVER_ERROR,
+  NOT_FOUND,
+  NO_CONTENT,
+  OK,
+  UNAUTHORIZED,
+} from 'src/constant/constant';
+import { UpdateIndexInWorkbookRequest } from '../dto/updateIndexInWorkbookRequest';
 
 @ApiTags('question')
 @Controller('/api/question')
@@ -86,12 +98,33 @@ export class QuestionController {
   @ApiResponse(
     createApiResponseOption(200, 'QuestionResponse 리스트', [QuestionResponse]),
   )
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
-  @ApiResponse(createApiResponseOption(401, 'T01', null))
-  @ApiResponse(createApiResponseOption(410, 'T02', null))
-  @ApiResponse(createApiResponseOption(400, 'W03', null))
+  @ApiResponse(createApiResponseOption(INTERNAL_SERVER_ERROR, 'SERVER', null))
+  @ApiResponse(createApiResponseOption(UNAUTHORIZED, 'T01', null))
+  @ApiResponse(createApiResponseOption(GONE, 'T02', null))
+  @ApiResponse(createApiResponseOption(BAD_REQUEST, 'W03', null))
   async findWorkbookQuestions(@Param('workbookId') workbookId: number) {
     return await this.questionService.findAllByWorkbookId(workbookId);
+  }
+
+  @Patch('/index')
+  @ApiOperation({
+    summary: '질문들의 인덱스 조정',
+  })
+  @ApiResponse(createApiResponseOption(OK, '없음', null))
+  @ApiResponse(createApiResponseOption(INTERNAL_SERVER_ERROR, 'SERVER', null))
+  @ApiResponse(createApiResponseOption(UNAUTHORIZED, 'T01', null))
+  @ApiResponse(createApiResponseOption(NOT_FOUND, 'W01', null))
+  @ApiResponse(createApiResponseOption(FORBIDDEN, 'W02', null))
+  @ApiResponse(createApiResponseOption(GONE, 'T02', null))
+  @ApiResponse(createApiResponseOption(BAD_REQUEST, 'W03', null))
+  async updateIndex(
+    @Body() updateIndexInWorkbookRequest: UpdateIndexInWorkbookRequest,
+    @Req() req: Request,
+  ) {
+    await this.questionService.updateIndex(
+      updateIndexInWorkbookRequest,
+      req.user as Member,
+    );
   }
 
   @Delete(':questionId')
@@ -100,12 +133,12 @@ export class QuestionController {
   @ApiOperation({
     summary: '질문 삭제',
   })
-  @ApiResponse(createApiResponseOption(204, '질문 삭제', null))
-  @ApiResponse(createApiResponseOption(401, 'T01', null))
-  @ApiResponse(createApiResponseOption(403, 'W02', null))
-  @ApiResponse(createApiResponseOption(404, 'W01, Q01', null))
-  @ApiResponse(createApiResponseOption(410, 'T02', null))
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
+  @ApiResponse(createApiResponseOption(NO_CONTENT, '질문 삭제', null))
+  @ApiResponse(createApiResponseOption(UNAUTHORIZED, 'T01', null))
+  @ApiResponse(createApiResponseOption(FORBIDDEN, 'W02', null))
+  @ApiResponse(createApiResponseOption(NOT_FOUND, 'W01, Q01', null))
+  @ApiResponse(createApiResponseOption(GONE, 'T02', null))
+  @ApiResponse(createApiResponseOption(INTERNAL_SERVER_ERROR, 'SERVER', null))
   async deleteQuestionById(
     @Param('questionId') questionId: number,
     @Req() req: Request,

--- a/src/question/dto/updateIndexInWorkbookRequest.ts
+++ b/src/question/dto/updateIndexInWorkbookRequest.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayMinSize, IsArray, IsNotEmpty, IsNumber } from 'class-validator';
+import { createPropertyOption } from 'src/util/swagger.util';
+
+export class UpdateIndexInWorkbookRequest {
+  @ApiProperty(createPropertyOption('1', '문제집 id', Number))
+  @IsNotEmpty()
+  @IsNumber()
+  workbookId: number;
+
+  @ApiProperty(createPropertyOption('1', '문제집 id', Number))
+  @IsArray()
+  @ArrayMinSize(1) // 최소 1개의 원소를 가져야 합니다.
+  @IsNumber({}, { each: true })
+  ids: number[];
+}

--- a/src/question/dto/updateIndexInWorkbookRequest.ts
+++ b/src/question/dto/updateIndexInWorkbookRequest.ts
@@ -13,4 +13,9 @@ export class UpdateIndexInWorkbookRequest {
   @ArrayMinSize(1) // 최소 1개의 원소를 가져야 합니다.
   @IsNumber({}, { each: true })
   ids: number[];
+
+  constructor(workbookId: number, ids: number[]) {
+    this.workbookId = workbookId;
+    this.ids = ids;
+  }
 }

--- a/src/question/entity/question.ts
+++ b/src/question/entity/question.ts
@@ -24,6 +24,9 @@ export class Question extends DefaultEntity {
   @JoinColumn({ name: 'defaultAnswer' })
   defaultAnswer: Answer;
 
+  @Column({ default: 0 })
+  indexInWorkbook: number;
+
   constructor(
     id: number,
     content: string,
@@ -37,6 +40,7 @@ export class Question extends DefaultEntity {
     this.workbook = workbook;
     this.origin = origin;
     this.defaultAnswer = defaultAnswer;
+    this.indexInWorkbook = 0;
   }
 
   static of(workbook: Workbook, origin: Question, content: string) {

--- a/src/question/entity/question.ts
+++ b/src/question/entity/question.ts
@@ -1,9 +1,10 @@
 import { DefaultEntity } from '../../app.entity';
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { Answer } from '../../answer/entity/answer';
 import { Workbook } from '../../workbook/entity/workbook';
 
 @Entity({ name: 'Question' })
+@Index('idx_indexInWorkbook', ['indexInWorkbook'])
 export class Question extends DefaultEntity {
   @Column({ type: 'text' })
   readonly content: string;

--- a/src/question/fixture/question.fixture.ts
+++ b/src/question/fixture/question.fixture.ts
@@ -2,6 +2,7 @@ import { Question } from '../entity/question';
 import { CreateQuestionRequest } from '../dto/createQuestionRequest';
 import { workbookFixtureWithId } from '../../workbook/fixture/workbook.fixture';
 import { CopyQuestionRequest } from '../dto/copyQuestionRequest';
+import { UpdateIndexInWorkbookRequest } from '../dto/updateIndexInWorkbookRequest';
 
 export const questionFixture = new Question(
   1,
@@ -21,3 +22,6 @@ export const copyQuestionRequestFixture = new CopyQuestionRequest(
   workbookFixtureWithId.id,
   [1, 2, 3],
 );
+
+export const updateIndexInWorkbookRequestFixture =
+  new UpdateIndexInWorkbookRequest(workbookFixtureWithId.id, [1, 2, 3]);

--- a/src/question/repository/question.repository.ts
+++ b/src/question/repository/question.repository.ts
@@ -72,6 +72,15 @@ export class QuestionRepository {
     await this.repository.remove(question);
   }
 
+  async updateIndex(ids: number[]) {
+    await this.repository
+      .createQueryBuilder()
+      .update(Question)
+      .set({ indexInWorkbook: () => 'FIND_IN_SET(id, :ids)' })
+      .where('id IN (:...ids)', { ids })
+      .execute();
+  }
+
   private fetchOrigin(question: Question) {
     if (!question) {
       return null;

--- a/src/question/repository/question.repository.ts
+++ b/src/question/repository/question.repository.ts
@@ -2,7 +2,6 @@ import { Repository } from 'typeorm';
 import { Question } from '../entity/question';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
 @Injectable()
 export class QuestionRepository {
@@ -34,6 +33,7 @@ export class QuestionRepository {
       .leftJoinAndSelect('Question.origin', 'origin')
       .leftJoinAndSelect('Question.defaultAnswer', 'defaultAnswer')
       .where('workbook.id = :workbookId', { workbookId })
+      .orderBy('Question.indexInWorkbook', 'ASC')
       .getMany();
   }
 

--- a/src/question/service/question.service.spec.ts
+++ b/src/question/service/question.service.spec.ts
@@ -341,10 +341,7 @@ describe('QuestionService', () => {
 
       //then
       await expect(
-        service.updateIndex(
-          updateIndexInWorkbookRequestFixture,
-          otherMemberFixture,
-        ),
+        service.updateIndex(updateIndexInWorkbookRequestFixture, memberFixture),
       ).rejects.toThrow(new QuestionNotFoundException());
     });
   });

--- a/src/question/service/question.service.spec.ts
+++ b/src/question/service/question.service.spec.ts
@@ -5,6 +5,7 @@ import {
   copyQuestionRequestFixture,
   createQuestionRequestFixture,
   questionFixture,
+  updateIndexInWorkbookRequestFixture,
 } from '../fixture/question.fixture';
 import { QuestionResponse } from '../dto/questionResponse';
 import {
@@ -53,6 +54,7 @@ describe('QuestionService', () => {
     findById: jest.fn(),
     remove: jest.fn(),
     findAllByIds: jest.fn(),
+    updateIndex: jest.fn(),
   };
 
   const mockWorkbookRepository = {
@@ -269,6 +271,81 @@ describe('QuestionService', () => {
       await expect(
         service.copyQuestions(copyQuestionRequestFixture, otherMemberFixture),
       ).rejects.toThrow(new WorkbookForbiddenException());
+    });
+  });
+
+  describe('질문 인덱스 변경', () => {
+    it('질문의 인덱스를 성공적으로 변경시킨다', async () => {
+      //given
+      mockQuestionRepository.findAllByIds.mockResolvedValue([
+        questionFixture,
+        questionFixture,
+        questionFixture,
+      ]);
+      mockQuestionRepository.updateIndex.mockResolvedValue(undefined);
+      mockWorkbookRepository.findById.mockResolvedValue(workbookFixtureWithId);
+      //when
+
+      //then
+      await expect(
+        service.updateIndex(updateIndexInWorkbookRequestFixture, memberFixture),
+      ).resolves.toBeUndefined();
+    });
+
+    it('문제집을 확인할 수 없으면 WorkbookNotFoundException을 반환한다', async () => {
+      //given
+      mockQuestionRepository.findAllByIds.mockResolvedValue([
+        questionFixture,
+        questionFixture,
+        questionFixture,
+      ]);
+      mockQuestionRepository.updateIndex.mockResolvedValue(undefined);
+      mockWorkbookRepository.findById.mockResolvedValue(undefined);
+      //when
+
+      //then
+      await expect(
+        service.updateIndex(updateIndexInWorkbookRequestFixture, memberFixture),
+      ).rejects.toThrow(new WorkbookNotFoundException());
+    });
+
+    it('문제집과 요청 회원이 다른 사람이면 WorkbookForbiddenException을 반환한다', async () => {
+      //given
+      mockQuestionRepository.findAllByIds.mockResolvedValue([
+        questionFixture,
+        questionFixture,
+        questionFixture,
+      ]);
+      mockQuestionRepository.updateIndex.mockResolvedValue(undefined);
+      mockWorkbookRepository.findById.mockResolvedValue(workbookFixtureWithId);
+      //when
+
+      //then
+      await expect(
+        service.updateIndex(
+          updateIndexInWorkbookRequestFixture,
+          otherMemberFixture,
+        ),
+      ).rejects.toThrow(new WorkbookForbiddenException());
+    });
+
+    it('질문이 존재하지 않는경우(입력받은 id배열의 길이와 DB에서 id로 조회한 결과가 다른 경우) QuestionNotFoundException을 반환한다', async () => {
+      //given
+      mockQuestionRepository.findAllByIds.mockResolvedValue([
+        questionFixture,
+        questionFixture,
+      ]);
+      mockQuestionRepository.updateIndex.mockResolvedValue(undefined);
+      mockWorkbookRepository.findById.mockResolvedValue(workbookFixtureWithId);
+      //when
+
+      //then
+      await expect(
+        service.updateIndex(
+          updateIndexInWorkbookRequestFixture,
+          otherMemberFixture,
+        ),
+      ).rejects.toThrow(new QuestionNotFoundException());
     });
   });
 });

--- a/src/question/service/question.service.spec.ts
+++ b/src/question/service/question.service.spec.ts
@@ -521,6 +521,6 @@ describe('QuestionService 통합 테스트', () => {
 
     //then
     const result = await questionRepository.findByWorkbookId(workbook.id);
-    expect(result.map((each) => each.indexInWorkbook)).toEqual([2, 0, 1]);
+    expect(result.map((each) => each.indexInWorkbook)).toEqual([0, 1, 2]);
   });
 });

--- a/src/question/service/question.service.spec.ts
+++ b/src/question/service/question.service.spec.ts
@@ -521,6 +521,6 @@ describe('QuestionService 통합 테스트', () => {
 
     //then
     const result = await questionRepository.findByWorkbookId(workbook.id);
-    expect(result.map((each) => each.indexInWorkbook)).toEqual([2, 3, 1]);
+    expect(result.map((each) => each.indexInWorkbook)).toEqual([2, 0, 1]);
   });
 });

--- a/src/question/service/question.service.ts
+++ b/src/question/service/question.service.ts
@@ -104,9 +104,11 @@ export class QuestionService {
       updateIndexRequest.workbookId,
       member,
     );
-    await this.validateQuestionsByIds(updateIndexRequest.ids);
-
-    this.questionRepository.updateIndex(updateIndexRequest.ids);
+    const questions = await this.questionRepository.findAllByIds(
+      updateIndexRequest.ids,
+    );
+    this.validateQuestionsByIds(questions, updateIndexRequest.ids);
+    await this.questionRepository.updateIndex(updateIndexRequest.ids);
   }
 
   private async validateMembersWorkbookById(
@@ -118,8 +120,7 @@ export class QuestionService {
     validateWorkbookOwner(workbook, member);
   }
 
-  private async validateQuestionsByIds(ids: number[]) {
-    const questions = await this.questionRepository.findAllByIds(ids);
+  private validateQuestionsByIds(questions: Question[], ids: number[]) {
     if (questions.length != ids.length) throw new QuestionNotFoundException();
   }
 

--- a/src/question/service/question.service.ts
+++ b/src/question/service/question.service.ts
@@ -104,9 +104,9 @@ export class QuestionService {
       updateIndexRequest.workbookId,
       member,
     );
-    const questions = await this.questionRepository.findAllByIds(
-      updateIndexRequest.ids,
-    );
+    const questions = (
+      await this.questionRepository.findAllByIds(updateIndexRequest.ids)
+    ).filter((each) => each.workbook.id === updateIndexRequest.workbookId);
     this.validateQuestionsByIds(questions, updateIndexRequest.ids);
     await this.questionRepository.updateIndex(updateIndexRequest.ids);
   }

--- a/src/question/service/question.service.ts
+++ b/src/question/service/question.service.ts
@@ -103,6 +103,9 @@ export class QuestionService {
       updateIndexRequest.workbookId,
       member,
     );
+    (
+      await this.questionRepository.findAllByIds(updateIndexRequest.ids)
+    ).forEach(validateQuestion);
 
     this.questionRepository.updateIndex(updateIndexRequest.ids);
   }

--- a/src/question/service/question.service.ts
+++ b/src/question/service/question.service.ts
@@ -17,6 +17,7 @@ import { Workbook } from '../../workbook/entity/workbook';
 import { WorkbookIdResponse } from '../../workbook/dto/workbookIdResponse';
 import { NeedToFindByWorkbookIdException } from '../../workbook/exception/workbook.exception';
 import { Transactional } from 'typeorm-transactional';
+import { UpdateIndexInWorkbookRequest } from '../dto/updateIndexInWorkbookRequest';
 
 @Injectable()
 export class QuestionService {
@@ -90,6 +91,20 @@ export class QuestionService {
     validateQuestion(question);
     await this.validateMembersWorkbookById(question.workbook.id, member);
     await this.questionRepository.remove(question);
+  }
+
+  @Transactional()
+  async updateIndex(
+    updateIndexRequest: UpdateIndexInWorkbookRequest,
+    member: Member,
+  ) {
+    validateManipulatedToken(member);
+    await this.validateMembersWorkbookById(
+      updateIndexRequest.workbookId,
+      member,
+    );
+
+    this.questionRepository.updateIndex(updateIndexRequest.ids);
   }
 
   private async validateMembersWorkbookById(

--- a/src/question/service/question.service.ts
+++ b/src/question/service/question.service.ts
@@ -18,6 +18,7 @@ import { WorkbookIdResponse } from '../../workbook/dto/workbookIdResponse';
 import { NeedToFindByWorkbookIdException } from '../../workbook/exception/workbook.exception';
 import { Transactional } from 'typeorm-transactional';
 import { UpdateIndexInWorkbookRequest } from '../dto/updateIndexInWorkbookRequest';
+import { QuestionNotFoundException } from '../exception/question.exception';
 
 @Injectable()
 export class QuestionService {
@@ -103,9 +104,7 @@ export class QuestionService {
       updateIndexRequest.workbookId,
       member,
     );
-    (
-      await this.questionRepository.findAllByIds(updateIndexRequest.ids)
-    ).forEach(validateQuestion);
+    await this.validateQuestionsByIds(updateIndexRequest.ids);
 
     this.questionRepository.updateIndex(updateIndexRequest.ids);
   }
@@ -117,6 +116,11 @@ export class QuestionService {
     const workbook = await this.workbookRepository.findById(workbookId);
     validateWorkbook(workbook);
     validateWorkbookOwner(workbook, member);
+  }
+
+  private async validateQuestionsByIds(ids: number[]) {
+    const questions = await this.questionRepository.findAllByIds(ids);
+    if (questions.length != ids.length) throw new QuestionNotFoundException();
   }
 
   private createCopy(question: Question, workbook: Workbook) {

--- a/src/util/exception.util.ts
+++ b/src/util/exception.util.ts
@@ -8,13 +8,20 @@ import {
   UNAUTHORIZED,
 } from '../constant/constant';
 import { LoggerService } from '../config/logger.config';
+import { ApiResponseOptions } from '@nestjs/swagger';
+import { createApiResponseOption } from './swagger.util';
 
 const errorLogger = new LoggerService('ERROR');
 
 class HttpCustomException extends HttpException {
+  apiResponse: ApiResponseOptions;
+
   constructor(message: string, errorCode: string, status: number) {
     super({ message: message, errorCode: errorCode }, status);
     errorLogger.error(errorCode, super.stack);
+
+    // 이 부분을 이용해서 Swagger의 createApiResponseOption의 반복구조를 지울 수 있을 것 같습니다.
+    this.apiResponse = createApiResponseOption(status, errorCode, null);
   }
 }
 


### PR DESCRIPTION
[![NDD-405](https://badgen.net/badge/JIRA/NDD-405/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-405) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=the-NDD&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- 프론트엔드의 UI/UX적 기획 : 문제집 내의 질문들을 드래그 앤 드랍으로 순서를 바꿀 수 있으면 좋겠다. 
- 이에 대한 기획 : 질문들의 id를 배열로 받아서 해당 인덱스들을 업데이트 시켜주자
    - 고려사항
        - 문제집에 대한 권한 검증 필요
        - 질문들에 대한 indexInWorkbook 인스턴스 필요
        - 인스턴스가 일괄적으로 업데이트 될 수 있기 때문에, update쿼리를 반복적으로 보내는 것이 아닌, 하나의 쿼리로 보내주어야 함
        - 문제집 id로 질문들을 조회하면 indexInWorkbook 컬럼의 asc로 정렬해주어야 함
        - indexInWorkbook을 통한 반복적인 정렬이 존재하기에 인덱싱이 필요

# How

```
// 초기 리포지토리 로직
async findByWorkbookId(workbookId: number) {
    return await this.repository
      .createQueryBuilder('Question')
      .leftJoinAndSelect('Question.workbook', 'workbook')
      .leftJoinAndSelect('Question.origin', 'origin')
      .leftJoinAndSelect('Question.defaultAnswer', 'defaultAnswer')
      .where('workbook.id = :workbookId', { workbookId })
      .orderBy('Question.indexInWorkbook', 'ASC')
      .getMany();
  }

async updateIndex(ids: number[]) {
    await this.repository
      .createQueryBuilder()
      .update(Question)
      .set({ indexInWorkbook: () => 'FIND_IN_SET(id, :ids)' })
      .where('id IN (:...ids)', { ids })
      .execute();
  }
```

이러한 방식으로 로직을 생성했다. 

## Issue
- 문제점 : 해당 방식의 업데이트는 Sqlite(테스트 환경)에서 동작하지 않는 문제가 있다. 
- 해결방안 : Raw Query를 체이닝을 이용해 만든 다음에 한번에 전송시키는 방식으로 업데이트를 시키자. 
- 결과
```
async updateIndex(ids: number[]) {
    const caseStatements = ids.map(
      (id) => `WHEN id = ${id} THEN ${ids.indexOf(id)}`,
    );

    const updateQuery = `
      UPDATE Question
      SET indexInWorkbook = CASE ${caseStatements.join(' ')} END
      WHERE id IN (${ids.join(', ')})
    `;

    await this.repository.query(updateQuery);
  }
```

```
// 비즈니스 로직
@Transactional()
  async updateIndex(
    updateIndexRequest: UpdateIndexInWorkbookRequest,
    member: Member,
  ) {
    validateManipulatedToken(member);
    await this.validateMembersWorkbookById(
      updateIndexRequest.workbookId,
      member,
    );
    const questions = (
      await this.questionRepository.findAllByIds(updateIndexRequest.ids)
    ).filter((each) => each.workbook.id === updateIndexRequest.workbookId);
    this.validateQuestionsByIds(questions, updateIndexRequest.ids);
    await this.questionRepository.updateIndex(updateIndexRequest.ids);
  }
```

1. 문제집 존재여부/권한여부 검증
2. 질문이 전부 존재하는지 검증(배열의 전체 길이를 확인해 길이가 다르다면 예외처리)
3. 인덱스 업데이트

```
// Controller
@Patch('/index')
  @UseGuards(TokenHardGuard)
  @ApiCookieAuth()
  @ApiOperation({
    summary: '질문들의 인덱스 조정',
  })
  @ApiResponse(createApiResponseOption(OK, '없음', null))
  @ApiResponse(createApiResponseOption(INTERNAL_SERVER_ERROR, 'SERVER', null))
  @ApiResponse(createApiResponseOption(UNAUTHORIZED, 'T01', null))
  @ApiResponse(createApiResponseOption(NOT_FOUND, 'W01', null))
  @ApiResponse(createApiResponseOption(FORBIDDEN, 'W02', null))
  @ApiResponse(createApiResponseOption(GONE, 'T02', null))
  @ApiResponse(createApiResponseOption(BAD_REQUEST, 'W03', null))
  async updateIndex(
    @Body() updateIndexInWorkbookRequest: UpdateIndexInWorkbookRequest,
    @Req() req: Request,
  ) {
    await this.questionService.updateIndex(
      updateIndexInWorkbookRequest,
      req.user as Member,
    );
  }
```
- 프론트엔드에서 인덱스를 수정하면 해당 인덱스대로 화면에 그대로 존재한다. 
- 성공시에는 프론트에서 아무런 데이터가 필요 없지만, 실패시에는 핸들링이 필요하다. 
- 즉, 상태코드 외에는 응답이 필요없다. 

# Result

<img width="979" alt="스크린샷 2024-01-11 13 58 53" src="https://github.com/the-NDD/Gomterview-BE/assets/99702271/c0ca28e2-eddf-4d90-8f5b-db82bcecf010">
<img width="531" alt="스크린샷 2024-01-11 13 59 11" src="https://github.com/the-NDD/Gomterview-BE/assets/99702271/c37c22e4-24b6-4f85-bc64-bdcdcef3d206">


# Prize

- 코드레벨적으로 개선사항이 나타났다.
```
@ApiResponse(createApiResponseOption(OK, '없음', null))
  @ApiResponse(createApiResponseOption(INTERNAL_SERVER_ERROR, 'SERVER', null))
  @ApiResponse(createApiResponseOption(UNAUTHORIZED, 'T01', null))
  @ApiResponse(createApiResponseOption(NOT_FOUND, 'W01', null))
  @ApiResponse(createApiResponseOption(FORBIDDEN, 'W02', null))
  @ApiResponse(createApiResponseOption(GONE, 'T02', null))
  @ApiResponse(createApiResponseOption(BAD_REQUEST, 'W03', null))
```
이 부분을 CustomException.getApiResponse()라는 static method로 사용하면 어떨까?

[NDD-405]: https://milk717.atlassian.net/browse/NDD-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ