### PR TITLE
[NDD-408] swagger의 api response문서화를 위한 로직을 예외클래스에 static method로 변경

### DIFF
--- a/src/answer/controller/answer.controller.ts
+++ b/src/answer/controller/answer.controller.ts
@@ -24,6 +24,19 @@ import { Member } from '../../member/entity/member';
 import { AnswerResponse } from '../dto/answerResponse';
 import { DefaultAnswerRequest } from '../dto/defaultAnswerRequest';
 import { TokenHardGuard } from 'src/token/guard/token.hard.guard';
+import {
+  InvalidTokenException,
+  ManipulatedTokenNotFiltered,
+  TokenExpiredException,
+} from 'src/token/exception/token.exception';
+import {
+  QuestionForbiddenException,
+  QuestionNotFoundException,
+} from 'src/question/exception/question.exception';
+import {
+  AnswerForbiddenException,
+  AnswerNotFoundException,
+} from '../exception/answer.exception';
 
 @ApiTags('answer')
 @Controller('/api/answer')
@@ -38,10 +51,10 @@ export class AnswerController {
     summary: '질문에 새로운 답변 추가',
   })
   @ApiResponse(createApiResponseOption(201, '답변 생성 완료', AnswerResponse))
-  @ApiResponse(createApiResponseOption(401, 'T01', null))
-  @ApiResponse(createApiResponseOption(404, 'Q01', null))
-  @ApiResponse(createApiResponseOption(410, 'T02', null))
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
+  @ApiResponse(InvalidTokenException.response())
+  @ApiResponse(QuestionNotFoundException.response())
+  @ApiResponse(TokenExpiredException.response())
+  @ApiResponse(ManipulatedTokenNotFiltered.response())
   async createAnswer(
     @Body() createAnswerRequest: CreateAnswerRequest,
     @Req() req: Request,
@@ -60,11 +73,11 @@ export class AnswerController {
     summary: '질문의 대표답변 설정',
   })
   @ApiResponse(createApiResponseOption(201, '대표답변 설정 완료', null))
-  @ApiResponse(createApiResponseOption(401, 'T01', null))
-  @ApiResponse(createApiResponseOption(403, 'Q02', null))
-  @ApiResponse(createApiResponseOption(404, 'A01, Q01', null))
-  @ApiResponse(createApiResponseOption(410, 'T02', null))
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
+  @ApiResponse(InvalidTokenException.response())
+  @ApiResponse(QuestionForbiddenException.response())
+  @ApiResponse(AnswerNotFoundException.response())
+  @ApiResponse(TokenExpiredException.response())
+  @ApiResponse(ManipulatedTokenNotFiltered.response())
   async updateDefaultAnswer(
     @Body() defaultAnswerRequest: DefaultAnswerRequest,
     @Req() req: Request,
@@ -82,7 +95,7 @@ export class AnswerController {
   @ApiResponse(
     createApiResponseOption(200, '답변 리스트 캡슐화해 반환', [AnswerResponse]),
   )
-  @ApiResponse(createApiResponseOption(404, 'Q01', null))
+  @ApiResponse(QuestionNotFoundException.response())
   async getQuestionAnswers(@Param('questionId') questionId: number) {
     return await this.answerService.getAnswerList(questionId);
   }
@@ -94,11 +107,11 @@ export class AnswerController {
     summary: '답변 삭제',
   })
   @ApiResponse(createApiResponseOption(204, '답변 삭제 완료', null))
-  @ApiResponse(createApiResponseOption(401, 'T01', null))
-  @ApiResponse(createApiResponseOption(403, 'A02', null))
-  @ApiResponse(createApiResponseOption(404, 'A01', null))
-  @ApiResponse(createApiResponseOption(410, 'T02', null))
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
+  @ApiResponse(InvalidTokenException.response())
+  @ApiResponse(AnswerForbiddenException.response())
+  @ApiResponse(AnswerNotFoundException.response())
+  @ApiResponse(TokenExpiredException.response())
+  @ApiResponse(ManipulatedTokenNotFiltered.response())
   async deleteAnswer(
     @Param('answerId') answerId: number,
     @Req() req: Request,

--- a/src/answer/exception/answer.exception.ts
+++ b/src/answer/exception/answer.exception.ts
@@ -1,17 +1,27 @@
+import { createApiResponseOption } from 'src/util/swagger.util';
 import {
   HttpForbiddenException,
   HttpNotFoundException,
 } from '../../util/exception.util';
+import { FORBIDDEN, NOT_FOUND } from 'src/constant/constant';
 
 class AnswerNotFoundException extends HttpNotFoundException {
   constructor() {
     super('해당 답변을 찾을 수 없습니다.', 'A01');
+  }
+
+  static response() {
+    return createApiResponseOption(NOT_FOUND, 'A01', null);
   }
 }
 
 class AnswerForbiddenException extends HttpForbiddenException {
   constructor() {
     super('답변에 대한 권한이 없습니다.', 'A02');
+  }
+
+  static response() {
+    return createApiResponseOption(FORBIDDEN, 'A02', null);
   }
 }
 

--- a/src/category/exception/category.exception.ts
+++ b/src/category/exception/category.exception.ts
@@ -1,8 +1,14 @@
+import { createApiResponseOption } from 'src/util/swagger.util';
 import { HttpNotFoundException } from '../../util/exception.util';
+import { NOT_FOUND } from 'src/constant/constant';
 
 class CategoryNotFoundException extends HttpNotFoundException {
   constructor() {
     super('카테고리가 존재하지 않습니다.', 'C02');
+  }
+
+  static response() {
+    return createApiResponseOption(NOT_FOUND, 'C02', null);
   }
 }
 

--- a/src/member/controller/member.controller.ts
+++ b/src/member/controller/member.controller.ts
@@ -13,6 +13,11 @@ import { MemberService } from '../service/member.service';
 import { validateManipulatedToken } from 'src/util/token.util';
 import { MemberNicknameResponse } from '../dto/memberNicknameResponse';
 import { TokenHardGuard } from 'src/token/guard/token.hard.guard';
+import {
+  InvalidTokenException,
+  ManipulatedTokenNotFiltered,
+  TokenExpiredException,
+} from 'src/token/exception/token.exception';
 
 @Controller('/api/member')
 @ApiTags('member')
@@ -32,7 +37,7 @@ export class MemberController {
       MemberResponse,
     ),
   )
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
+  @ApiResponse(ManipulatedTokenNotFiltered.response())
   getMyInfo(@Req() req: Request) {
     validateManipulatedToken(req.user as Member);
     return MemberResponse.from(req.user as Member);
@@ -49,8 +54,8 @@ export class MemberController {
       MemberNicknameResponse,
     ),
   )
-  @ApiResponse(createApiResponseOption(401, 'T01', null))
-  @ApiResponse(createApiResponseOption(410, 'T02', null))
+  @ApiResponse(InvalidTokenException.response())
+  @ApiResponse(TokenExpiredException.response())
   async getNameForInterview(@Req() req: Request) {
     return await this.memberService.getNameForInterview(req);
   }

--- a/src/member/exception/member.exception.ts
+++ b/src/member/exception/member.exception.ts
@@ -1,7 +1,13 @@
+import { NOT_FOUND } from 'src/constant/constant';
 import { HttpNotFoundException } from 'src/util/exception.util';
+import { createApiResponseOption } from 'src/util/swagger.util';
 
 export class MemberNotFoundException extends HttpNotFoundException {
   constructor() {
     super('회원을 찾을 수 없습니다.', 'M01');
+  }
+
+  static response() {
+    return createApiResponseOption(NOT_FOUND, 'M01', null);
   }
 }

--- a/src/question/controller/question.controller.ts
+++ b/src/question/controller/question.controller.ts
@@ -37,6 +37,16 @@ import {
   UNAUTHORIZED,
 } from 'src/constant/constant';
 import { UpdateIndexInWorkbookRequest } from '../dto/updateIndexInWorkbookRequest';
+import {
+  InvalidTokenException,
+  ManipulatedTokenNotFiltered,
+  TokenExpiredException,
+} from 'src/token/exception/token.exception';
+import {
+  NeedToFindByWorkbookIdException,
+  WorkbookForbiddenException,
+  WorkbookNotFoundException,
+} from 'src/workbook/exception/workbook.exception';
 
 @ApiTags('question')
 @Controller('/api/question')
@@ -53,11 +63,11 @@ export class QuestionController {
   @ApiResponse(
     createApiResponseOption(201, '커스텀 질문 저장 완료', QuestionResponse),
   )
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
-  @ApiResponse(createApiResponseOption(401, 'T01', null))
-  @ApiResponse(createApiResponseOption(410, 'T02', null))
-  @ApiResponse(createApiResponseOption(404, 'W01', null))
-  @ApiResponse(createApiResponseOption(403, 'W02', null))
+  @ApiResponse(ManipulatedTokenNotFiltered.response())
+  @ApiResponse(InvalidTokenException.response())
+  @ApiResponse(TokenExpiredException.response())
+  @ApiResponse(WorkbookNotFoundException.response())
+  @ApiResponse(WorkbookForbiddenException.response())
   async createCustomQuestion(
     @Body() createQuestionRequest: CreateQuestionRequest,
     @Req() req: Request,
@@ -76,11 +86,11 @@ export class QuestionController {
     summary: '질문 복제',
   })
   @ApiResponse(createApiResponseOption(201, '질문 복제', WorkbookIdResponse))
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
-  @ApiResponse(createApiResponseOption(401, 'T01', null))
-  @ApiResponse(createApiResponseOption(410, 'T02', null))
-  @ApiResponse(createApiResponseOption(404, 'W01', null))
-  @ApiResponse(createApiResponseOption(403, 'W02', null))
+  @ApiResponse(ManipulatedTokenNotFiltered.response())
+  @ApiResponse(InvalidTokenException.response())
+  @ApiResponse(TokenExpiredException.response())
+  @ApiResponse(WorkbookNotFoundException.response())
+  @ApiResponse(WorkbookForbiddenException.response())
   async copyQuestions(
     @Body() copyQuestionRequest: CopyQuestionRequest,
     @Req() req: Request,
@@ -98,10 +108,11 @@ export class QuestionController {
   @ApiResponse(
     createApiResponseOption(200, 'QuestionResponse 리스트', [QuestionResponse]),
   )
-  @ApiResponse(createApiResponseOption(INTERNAL_SERVER_ERROR, 'SERVER', null))
-  @ApiResponse(createApiResponseOption(UNAUTHORIZED, 'T01', null))
-  @ApiResponse(createApiResponseOption(GONE, 'T02', null))
   @ApiResponse(createApiResponseOption(BAD_REQUEST, 'W03', null))
+  @ApiResponse(ManipulatedTokenNotFiltered.response())
+  @ApiResponse(InvalidTokenException.response())
+  @ApiResponse(TokenExpiredException.response())
+  @ApiResponse(NeedToFindByWorkbookIdException.response())
   async findWorkbookQuestions(@Param('workbookId') workbookId: number) {
     return await this.questionService.findAllByWorkbookId(workbookId);
   }
@@ -113,12 +124,12 @@ export class QuestionController {
     summary: '질문들의 인덱스 조정',
   })
   @ApiResponse(createApiResponseOption(OK, '없음', null))
-  @ApiResponse(createApiResponseOption(INTERNAL_SERVER_ERROR, 'SERVER', null))
-  @ApiResponse(createApiResponseOption(UNAUTHORIZED, 'T01', null))
-  @ApiResponse(createApiResponseOption(NOT_FOUND, 'W01', null))
-  @ApiResponse(createApiResponseOption(FORBIDDEN, 'W02', null))
-  @ApiResponse(createApiResponseOption(GONE, 'T02', null))
-  @ApiResponse(createApiResponseOption(BAD_REQUEST, 'W03', null))
+  @ApiResponse(ManipulatedTokenNotFiltered.response())
+  @ApiResponse(InvalidTokenException.response())
+  @ApiResponse(TokenExpiredException.response())
+  @ApiResponse(WorkbookNotFoundException.response())
+  @ApiResponse(WorkbookForbiddenException.response())
+  @ApiResponse(NeedToFindByWorkbookIdException.response())
   async updateIndex(
     @Body() updateIndexInWorkbookRequest: UpdateIndexInWorkbookRequest,
     @Req() req: Request,
@@ -136,11 +147,11 @@ export class QuestionController {
     summary: '질문 삭제',
   })
   @ApiResponse(createApiResponseOption(NO_CONTENT, '질문 삭제', null))
-  @ApiResponse(createApiResponseOption(UNAUTHORIZED, 'T01', null))
-  @ApiResponse(createApiResponseOption(FORBIDDEN, 'W02', null))
   @ApiResponse(createApiResponseOption(NOT_FOUND, 'W01, Q01', null))
-  @ApiResponse(createApiResponseOption(GONE, 'T02', null))
-  @ApiResponse(createApiResponseOption(INTERNAL_SERVER_ERROR, 'SERVER', null))
+  @ApiResponse(ManipulatedTokenNotFiltered.response())
+  @ApiResponse(InvalidTokenException.response())
+  @ApiResponse(TokenExpiredException.response())
+  @ApiResponse(WorkbookForbiddenException.response())
   async deleteQuestionById(
     @Param('questionId') questionId: number,
     @Req() req: Request,

--- a/src/question/exception/question.exception.ts
+++ b/src/question/exception/question.exception.ts
@@ -1,17 +1,27 @@
+import { createApiResponseOption } from 'src/util/swagger.util';
 import {
   HttpForbiddenException,
   HttpNotFoundException,
 } from '../../util/exception.util';
+import { FORBIDDEN, NOT_FOUND } from 'src/constant/constant';
 
 class QuestionNotFoundException extends HttpNotFoundException {
   constructor() {
     super('해당 질문을 찾을 수 없습니다.', 'Q01');
+  }
+
+  static response() {
+    return createApiResponseOption(NOT_FOUND, 'Q01', null);
   }
 }
 
 class QuestionForbiddenException extends HttpForbiddenException {
   constructor() {
     super('질문에 대한 권한이 없습니다.', 'Q02');
+  }
+
+  static response() {
+    return createApiResponseOption(FORBIDDEN, 'Q02', null);
   }
 }
 

--- a/src/token/exception/token.exception.ts
+++ b/src/token/exception/token.exception.ts
@@ -1,12 +1,22 @@
+import { createApiResponseOption } from 'src/util/swagger.util';
 import {
   HttpGoneException,
   HttpInternalServerError,
   HttpUnauthorizedException,
 } from '../../util/exception.util';
+import {
+  GONE,
+  INTERNAL_SERVER_ERROR,
+  UNAUTHORIZED,
+} from 'src/constant/constant';
 
 class InvalidTokenException extends HttpUnauthorizedException {
   constructor() {
     super('유효하지 않은 토큰입니다.', 'T01');
+  }
+
+  static response() {
+    return createApiResponseOption(UNAUTHORIZED, 'T01', null);
   }
 }
 
@@ -14,17 +24,29 @@ class TokenExpiredException extends HttpGoneException {
   constructor() {
     super('토큰이 만료되었습니다', 'T02');
   }
+
+  static response() {
+    return createApiResponseOption(GONE, 'T02', null);
+  }
 }
 
 class NeedToLoginException extends HttpUnauthorizedException {
   constructor() {
     super('다시 로그인해주세요.', 'T03');
   }
+
+  static response() {
+    return createApiResponseOption(UNAUTHORIZED, 'T03', null);
+  }
 }
 
 class ManipulatedTokenNotFiltered extends HttpInternalServerError {
   constructor() {
     super('', 'SERVER');
+  }
+
+  static response() {
+    return createApiResponseOption(INTERNAL_SERVER_ERROR, 'SERVER', null);
   }
 }
 

--- a/src/video/exception/video.exception.ts
+++ b/src/video/exception/video.exception.ts
@@ -1,13 +1,24 @@
 import {
+  BAD_REQUEST,
+  FORBIDDEN,
+  INTERNAL_SERVER_ERROR,
+  NOT_FOUND,
+} from 'src/constant/constant';
+import {
   HttpBadRequestException,
   HttpForbiddenException,
   HttpInternalServerError,
   HttpNotFoundException,
 } from 'src/util/exception.util';
+import { createApiResponseOption } from 'src/util/swagger.util';
 
 export class IDriveException extends HttpInternalServerError {
   constructor() {
     super('비디오 업로드 API 처리 도중 에러가 발생하였습니다.', 'V01');
+  }
+
+  static response() {
+    return createApiResponseOption(INTERNAL_SERVER_ERROR, 'V01', null);
   }
 }
 
@@ -15,11 +26,19 @@ export class VideoAccessForbiddenException extends HttpForbiddenException {
   constructor() {
     super('해당 비디오에 접근 권한이 없습니다.', 'V02');
   }
+
+  static response() {
+    return createApiResponseOption(FORBIDDEN, 'V02', null);
+  }
 }
 
 export class VideoNotFoundException extends HttpNotFoundException {
   constructor() {
     super('존재하지 않는 비디오입니다.', 'V03');
+  }
+
+  static response() {
+    return createApiResponseOption(NOT_FOUND, 'V03', null);
   }
 }
 
@@ -27,11 +46,19 @@ export class VideoOfWithdrawnMemberException extends HttpNotFoundException {
   constructor() {
     super('탈퇴한 회원의 비디오를 조회할 수 없습니다.', 'V04');
   }
+
+  static response() {
+    return createApiResponseOption(NOT_FOUND, 'V04', null);
+  }
 }
 
 export class RedisDeleteException extends HttpInternalServerError {
   constructor() {
     super('비디오 정보 삭제 중 오류가 발생하였습니다.', 'V05');
+  }
+
+  static response() {
+    return createApiResponseOption(INTERNAL_SERVER_ERROR, 'V05', null);
   }
 }
 
@@ -39,11 +66,19 @@ export class RedisRetrieveException extends HttpInternalServerError {
   constructor() {
     super('비디오 정보를 가져오는 중 오류가 발생하였습니다.', 'V06');
   }
+
+  static response() {
+    return createApiResponseOption(INTERNAL_SERVER_ERROR, 'V06', null);
+  }
 }
 
 export class RedisSaveException extends HttpInternalServerError {
   constructor() {
     super('비디오 정보 저장 중 오류가 발생하였습니다.', 'V07');
+  }
+
+  static response() {
+    return createApiResponseOption(INTERNAL_SERVER_ERROR, 'V07', null);
   }
 }
 
@@ -51,16 +86,28 @@ export class Md5HashException extends HttpInternalServerError {
   constructor() {
     super('해시 생성 중 오류가 발생했습니다.', 'V08');
   }
+
+  static response() {
+    return createApiResponseOption(INTERNAL_SERVER_ERROR, 'V08', null);
+  }
 }
 
 export class VideoNotFoundWithHashException extends HttpNotFoundException {
   constructor() {
     super('해당 해시값으로 등록된 비디오를 조회할 수 없습니다.', 'V09');
   }
+
+  static response() {
+    return createApiResponseOption(NOT_FOUND, 'V09', null);
+  }
 }
 
 export class InvalidHashException extends HttpBadRequestException {
   constructor() {
     super('유효하지 않은 해시값입니다.', 'V10');
+  }
+
+  static response() {
+    return createApiResponseOption(BAD_REQUEST, 'V10', null);
   }
 }

--- a/src/workbook/controller/workbook.controller.ts
+++ b/src/workbook/controller/workbook.controller.ts
@@ -31,6 +31,16 @@ import { TokenSoftGuard } from '../../token/guard/token.soft.guard';
 import { isEmpty } from 'class-validator';
 import { UpdateWorkbookRequest } from '../dto/updateWorkbookRequest';
 import { TokenHardGuard } from 'src/token/guard/token.hard.guard';
+import {
+  InvalidTokenException,
+  ManipulatedTokenNotFiltered,
+  TokenExpiredException,
+} from 'src/token/exception/token.exception';
+import { CategoryNotFoundException } from 'src/category/exception/category.exception';
+import {
+  WorkbookForbiddenException,
+  WorkbookNotFoundException,
+} from '../exception/workbook.exception';
 
 @ApiTags('workbook')
 @Controller('/api/workbook')
@@ -47,10 +57,10 @@ export class WorkbookController {
   @ApiResponse(
     createApiResponseOption(201, '문제집 생성 완료', WorkbookIdResponse),
   )
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
-  @ApiResponse(createApiResponseOption(401, 'T01', null))
-  @ApiResponse(createApiResponseOption(404, 'C02', null))
-  @ApiResponse(createApiResponseOption(410, 'T02', null))
+  @ApiResponse(ManipulatedTokenNotFiltered.response())
+  @ApiResponse(InvalidTokenException.response())
+  @ApiResponse(CategoryNotFoundException.response())
+  @ApiResponse(TokenExpiredException.response())
   async createAnswer(
     @Body() createWorkbookRequest: CreateWorkbookRequest,
     @Req() req: Request,
@@ -74,7 +84,7 @@ export class WorkbookController {
       WorkbookResponse,
     ]),
   )
-  @ApiResponse(createApiResponseOption(404, 'C02', null))
+  @ApiResponse(CategoryNotFoundException.response())
   async findWorkbooks(@Query('category') categoryId: number) {
     return await this.workbookService.findWorkbooks(categoryId);
   }
@@ -90,9 +100,9 @@ export class WorkbookController {
       WorkbookTitleResponse,
     ]),
   )
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
-  @ApiResponse(createApiResponseOption(401, 'T01', null))
-  @ApiResponse(createApiResponseOption(410, 'T02', null))
+  @ApiResponse(ManipulatedTokenNotFiltered.response())
+  @ApiResponse(InvalidTokenException.response())
+  @ApiResponse(TokenExpiredException.response())
   async findMembersWorkbook(@Req() req: Request) {
     const member = isEmpty(req) ? null : (req.user as Member);
     return await this.workbookService.findWorkbookTitles(member);
@@ -105,7 +115,7 @@ export class WorkbookController {
   @ApiResponse(
     createApiResponseOption(200, '문제집 단건 조회', WorkbookResponse),
   )
-  @ApiResponse(createApiResponseOption(404, 'W01', null))
+  @ApiResponse(WorkbookNotFoundException.response())
   async findSingleWorkbook(@Param('workbookId') workbookId: number) {
     return await this.workbookService.findSingleWorkbook(workbookId);
   }
@@ -120,9 +130,9 @@ export class WorkbookController {
   @ApiResponse(
     createApiResponseOption(200, '문제집 수정 완료', WorkbookResponse),
   )
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
-  @ApiResponse(createApiResponseOption(404, 'C02, W01', null))
-  @ApiResponse(createApiResponseOption(403, 'W02', null))
+  @ApiResponse(ManipulatedTokenNotFiltered.response())
+  @ApiResponse(CategoryNotFoundException.response())
+  @ApiResponse(WorkbookForbiddenException.response())
   async updateAnswer(
     @Body() updateWorkbookRequest: UpdateWorkbookRequest,
     @Req() req: Request,
@@ -140,9 +150,9 @@ export class WorkbookController {
     summary: '문제집 삭제',
   })
   @ApiResponse(createApiResponseOption(204, '문제집 삭제 완료', null))
-  @ApiResponse(createApiResponseOption(500, 'SERVER', null))
-  @ApiResponse(createApiResponseOption(404, 'W01', null))
-  @ApiResponse(createApiResponseOption(403, 'W02', null))
+  @ApiResponse(ManipulatedTokenNotFiltered.response())
+  @ApiResponse(WorkbookNotFoundException.response())
+  @ApiResponse(WorkbookForbiddenException.response())
   async deleteAnswer(
     @Req() req: Request,
     @Param('workbookId') workbookId: number,

--- a/src/workbook/exception/workbook.exception.ts
+++ b/src/workbook/exception/workbook.exception.ts
@@ -1,12 +1,18 @@
+import { createApiResponseOption } from 'src/util/swagger.util';
 import {
   HttpBadRequestException,
   HttpForbiddenException,
   HttpNotFoundException,
 } from '../../util/exception.util';
+import { BAD_REQUEST, FORBIDDEN, NOT_FOUND } from 'src/constant/constant';
 
 class WorkbookNotFoundException extends HttpNotFoundException {
   constructor() {
     super('문제집을 찾을 수 없습니다.', 'W01');
+  }
+
+  static response() {
+    return createApiResponseOption(NOT_FOUND, 'W01', null);
   }
 }
 
@@ -14,11 +20,19 @@ class WorkbookForbiddenException extends HttpForbiddenException {
   constructor() {
     super('문제집에 대한 권한이 없습니다.', 'W02');
   }
+
+  static response() {
+    return createApiResponseOption(FORBIDDEN, 'W02', null);
+  }
 }
 
 class NeedToFindByWorkbookIdException extends HttpBadRequestException {
   constructor() {
     super('문제집 id를 입력해주세요.', 'W03');
+  }
+
+  static response() {
+    return createApiResponseOption(BAD_REQUEST, 'W03', null);
   }
 }
 


### PR DESCRIPTION
[![NDD-408](https://badgen.net/badge/JIRA/NDD-408/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-408) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=the-NDD&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why & How

```
@ApiResponse(
    createApiResponseOption(
      200,
      '해시값을 사용하여 비디오 정보 조회 완료',
      VideoDetailResponse,
    ),
  )
  @ApiResponse(createApiResponseOption(400, 'V10', null))
  @ApiResponse(createApiResponseOption(403, 'V02', null))
  @ApiResponse(createApiResponseOption(404, 'V03, V04, V09, M01', null))
  @ApiResponse(createApiResponseOption(500, 'V06', null))
```

- 이러한 로직에서 성공값은 그 때 마다 만들어주어야 하기에 만드는게 맞을 수 있다고 생각된다. 
- 하지만, 예외케이스들을 항상 매직넘버를 이용해 이렇게 처리할 경우, 가독성적인 측면에서 좋지 않다. 
- 404에러같은 경우에는 여러 케이스들이 같이 존재할 수 있어 직접 추가를 해야하지만, 이렇게 어쩔 수 없는 경우를 제외하고는 static method를 통해 어떤 예외 클래스인지 명시하는 것이 더 좋아보인다. 
- 복수의 에러코드들을 상태코드 하나가 가진다면, 해당 부분은 에러클래스를 주석으로 남겨두는 것도 좋다고 생각된다. 

```
@ApiResponse(
    createApiResponseOption(201, '문제집 생성 완료', WorkbookIdResponse),
  )
  @ApiResponse(ManipulatedTokenNotFiltered.response())
  @ApiResponse(InvalidTokenException.response())
  @ApiResponse(CategoryNotFoundException.response())
  @ApiResponse(TokenExpiredException.response())
```
어떤 예외클래스인지 확인하기 더 수월해진다는 장점이 존재한다. 

# Result

<img width="336" alt="스크린샷 2024-01-11 19 24 34" src="https://github.com/the-NDD/Gomterview-BE/assets/99702271/7b88e98e-783d-4400-9a45-2423f6e94496">
이전과 같은 로직을 더 깔끔한 코드로 사용할 수 있다. 

# Prize

- Video를 제외한 모든 케이스를 핸들링할 수 있다. (Video는 현재 진행중인 태스크가 있고, 이후에 Video에 UI/UX를 위한 커스텀 인덱스를 추가해야하기에 해당 태스크중에 추가작업을 하려고 한다. 
- 이외의 모든 로직의 swagger exception에 대해서는 문서화 코드를 수정했다.

[NDD-408]: https://milk717.atlassian.net/browse/NDD-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ