### PR TITLE
[NDD-409] 서버에서 비디오 삭제 시 IDrive에서도 삭제되도록 구현 (2h / 2h)

### DIFF
--- a/src/constant/constant.ts
+++ b/src/constant/constant.ts
@@ -35,3 +35,6 @@ export const REFRESH_TOKEN_EXPIRES_IN = process.env.REFRESH_TOKEN_EXPIRES_IN; //
 export const NO_CACHE_URL = ['/api/member', '/api/auth/reissue'];
 export const HOUR_IN_SECONDS = 60 * 60;
 export const WEEK_IN_SECONDS = 60 * 60 * 24 * 7;
+
+export const IDRIVE_VIDEO_ENDPOINT = `${process.env.IDRIVE_STORAGE_URL}/videos/`;
+export const IDRIVE_THUMBNAIL_ENDPOINT = `${process.env.IDRIVE_STORAGE_URL}/thumbnail/`;

--- a/src/util/idrive.util.ts
+++ b/src/util/idrive.util.ts
@@ -1,4 +1,8 @@
-import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+  DeleteObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { IDRIVE_CONFIG } from 'src/config/idrive.config';
 
@@ -21,3 +25,16 @@ export async function getSignedUrlWithKey(key: string, isVideo: boolean) {
 
   return await getSignedUrl(s3, command, { expiresIn });
 }
+
+const getDeleteCommangObject = (
+  key: string,
+  isVideo: boolean,
+): DeleteObjectCommand =>
+  new DeleteObjectCommand({
+    Bucket: isVideo ? 'videos' : 'thumbnail',
+    Key: key,
+  });
+
+export const deleteObjectInIdrive = async (key: string, isVideo: boolean) => {
+  return await s3Client.send(getDeleteCommangObject(key, isVideo));
+};

--- a/src/util/idrive.util.ts
+++ b/src/util/idrive.util.ts
@@ -35,6 +35,6 @@ const getDeleteCommangObject = (
     Key: key,
   });
 
-export const deleteObjectInIdrive = async (key: string, isVideo: boolean) => {
+export const deleteObjectInIDrive = async (key: string, isVideo: boolean) => {
   return await s3Client.send(getDeleteCommangObject(key, isVideo));
 };

--- a/src/video/controller/video.controller.ts
+++ b/src/video/controller/video.controller.ts
@@ -233,7 +233,7 @@ export class VideoController {
   @ApiResponse(createApiResponseOption(204, '비디오 삭제 완료', null))
   @ApiResponse(VideoAccessForbiddenException.response())
   @ApiResponse(VideoNotFoundException.response())
-  @ApiResponse(ManipulatedTokenNotFiltered.response())
+  @ApiResponse(createApiResponseOption(500, 'V12, SERVER', null))
   async deleteVideo(
     @Param('videoId') videoId: number,
     @Req() req: Request,

--- a/src/video/exception/video.exception.ts
+++ b/src/video/exception/video.exception.ts
@@ -124,3 +124,13 @@ export class VideoLackException extends HttpBadRequestException {
     return createApiResponseOption(BAD_REQUEST, 'V11', null);
   }
 }
+
+export class DeleteObjectFailedException extends HttpInternalServerError {
+  constructor(type: string) {
+    super(`IDrive에서 ${type} 삭제 중에 오류가 발생했습니다.`, 'V12');
+  }
+
+  static response() {
+    return createApiResponseOption(INTERNAL_SERVER_ERROR, 'V12', null);
+  }
+}

--- a/src/video/service/video.service.spec.ts
+++ b/src/video/service/video.service.spec.ts
@@ -52,8 +52,6 @@ import { DEFAULT_THUMBNAIL } from '../../constant/constant';
 import * as idriveUtil from 'src/util/idrive.util';
 import redisMock from 'ioredis-mock';
 import { UpdateVideoIndexRequest } from '../dto/updateVideoIndexRequest';
-import { Member } from 'src/member/entity/member';
-import { UpdateVideoRequest } from '../dto/updateVideoRequest';
 
 describe('VideoService 단위 테스트', () => {
   let videoService: VideoService;
@@ -780,8 +778,14 @@ describe('VideoService 단위 테스트', () => {
   describe('deleteVideo', () => {
     const member = memberFixture;
 
-    it('비디오 삭제 성공 시 undefined로 반환된다.', () => {
+    it('비디오 삭제 성공 시 undefined로 반환된다.', async () => {
       // given
+      const deleteObjectInIDriveSpy = jest.spyOn(
+        idriveUtil,
+        'deleteObjectInIDrive',
+      );
+      deleteObjectInIDriveSpy.mockResolvedValue(undefined);
+
       const video = videoFixture;
 
       // when
@@ -789,9 +793,11 @@ describe('VideoService 단위 테스트', () => {
       mockVideoRepository.remove.mockResolvedValue(undefined);
 
       // then
-      expect(
+      await expect(
         videoService.deleteVideo(video.id, member),
       ).resolves.toBeUndefined();
+
+      deleteObjectInIDriveSpy.mockRestore();
     });
 
     it('비디오 삭제 시 member가 없으면 ManipulatedTokenNotFiltered을 반환한다.', () => {
@@ -1361,6 +1367,12 @@ describe('VideoService 통합 테스트', () => {
   describe('deleteVideo', () => {
     it('비디오 삭제에 성공하면 undefined를 반환한다.', async () => {
       // given
+      const deleteObjectInIDriveSpy = jest.spyOn(
+        idriveUtil,
+        'deleteObjectInIDrive',
+      );
+      deleteObjectInIDriveSpy.mockResolvedValue(undefined);
+
       const member = memberFixture;
       const video = await videoRepository.save(videoFixture);
 
@@ -1370,6 +1382,8 @@ describe('VideoService 통합 테스트', () => {
       await expect(
         videoService.deleteVideo(video.id, member),
       ).resolves.toBeUndefined();
+
+      deleteObjectInIDriveSpy.mockRestore();
     });
 
     it('비디오 삭제 시 member가 없으면 ManipulatedTokenNotFiltered를 반환한다.', async () => {

--- a/src/video/service/video.service.ts
+++ b/src/video/service/video.service.ts
@@ -31,7 +31,7 @@ import {
 import { SingleVideoResponse } from '../dto/singleVideoResponse';
 import { MemberNotFoundException } from 'src/member/exception/member.exception';
 import {
-  deleteObjectInIdrive,
+  deleteObjectInIDrive,
   getSignedUrlWithKey,
 } from 'src/util/idrive.util';
 import { PreSignedInfo } from '../interface/video.interface';
@@ -193,7 +193,7 @@ export class VideoService {
     const video = await this.videoRepository.findById(videoId);
     this.validateVideoOwnership(video, memberId);
 
-    deleteVideoAndThumbnailInIDrive(video.url, video.thumbnail);
+    await this.deleteVideoAndThumbnailInIDrive(video.url, video.thumbnail);
     await this.videoRepository.remove(video);
   }
 
@@ -281,22 +281,23 @@ export class VideoService {
 
     return true;
   }
-}
-function deleteVideoAndThumbnailInIDrive(
-  videoUrl: string,
-  thumbnailUrl: string,
-) {
-  const videoKey = videoUrl.split(IDRIVE_VIDEO_ENDPOINT)[1];
-  const thumbnailKey = thumbnailUrl.split(IDRIVE_THUMBNAIL_ENDPOINT)[1];
-  try {
-    deleteObjectInIdrive(videoKey, true);
-  } catch (error) {
-    throw new DeleteObjectFailedException('비디오');
-  }
 
-  try {
-    deleteObjectInIdrive(thumbnailKey, false);
-  } catch (error) {
-    throw new DeleteObjectFailedException('썸네일 이미지');
+  private async deleteVideoAndThumbnailInIDrive(
+    videoUrl: string,
+    thumbnailUrl: string,
+  ) {
+    const videoKey = videoUrl.split(IDRIVE_VIDEO_ENDPOINT)[1];
+    const thumbnailKey = thumbnailUrl.split(IDRIVE_THUMBNAIL_ENDPOINT)[1];
+    try {
+      await deleteObjectInIDrive(videoKey, true);
+    } catch (error) {
+      throw new DeleteObjectFailedException('비디오');
+    }
+
+    try {
+      await deleteObjectInIDrive(thumbnailKey, false);
+    } catch (error) {
+      throw new DeleteObjectFailedException('썸네일 이미지');
+    }
   }
 }


### PR DESCRIPTION
[![NDD-409](https://badgen.net/badge/JIRA/NDD-409/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-409) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=the-NDD&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
만약 DB에 저장된 비디오 정보가 제거가 되면, 더 이상 그 비디오 영상과 썸네일에 대해서는 접근이 불가능하기에 IDrive에서도 삭제가 되어야하지만, 기존 구현 시 이를 구현하지 않은 상태였습니다. 이를 개선하기 위해 진행했습니다.

# How
아래와 같이 AWS SDK for JavaScript를 사용하여, S3 Object의 단일 삭제 로직을 이용해 구현하였습니다.
```JavaScript
const getDeleteCommangObject = (
  key: string,
  isVideo: boolean,
): DeleteObjectCommand =>
  new DeleteObjectCommand({
    Bucket: isVideo ? 'videos' : 'thumbnail',
    Key: key,
  });

export const deleteObjectInIDrive = async (key: string, isVideo: boolean) => {
  return await s3Client.send(getDeleteCommangObject(key, isVideo));
};
```

# Result
DB에서 비디오를 삭제하기 위한 API를 요청할 시 이제 비디오 영상과 썸네일도 모두 IDrive에서 삭제가 됩니다.

# Prize
사용하지 않는 비디오 영상과 썸네일도 IDrive에서 삭제가 되기 때문에, IDrive 상에서 쓸데 없이 용량을 차지하지 않도록 할 수 있습니다.

# Reference
https://docs.aws.amazon.com/ko_kr/AmazonS3/latest/userguide/delete-objects.html

[NDD-409]: https://milk717.atlassian.net/browse/NDD-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ