### PR TITLE
[NDD-417] IDrive 삭제 로직 구현 후 비디오 삭제가 되지 않는 버그 해결

### DIFF
--- a/src/util/idrive.util.ts
+++ b/src/util/idrive.util.ts
@@ -36,5 +36,6 @@ const getDeleteCommangObject = (
   });
 
 export const deleteObjectInIDrive = async (key: string, isVideo: boolean) => {
+  const s3Client = getIdriveS3Client();
   return await s3Client.send(getDeleteCommangObject(key, isVideo));
 };

--- a/src/video/service/video.service.ts
+++ b/src/video/service/video.service.ts
@@ -21,7 +21,6 @@ import { isEmpty, notEquals } from 'class-validator';
 import { VideoDetailResponse } from '../dto/videoDetailResponse';
 import * as crypto from 'crypto';
 import 'dotenv/config';
-import { VideoHashResponse } from '../dto/videoHashResponse';
 import { MemberRepository } from 'src/member/repository/member.repository';
 import {
   deleteFromRedis,
@@ -174,7 +173,7 @@ export class VideoService {
   async findAllRelatedVideoById(videoId: number, member: Member) {
     const video = await this.videoRepository.findById(videoId);
     if (!video) throw new VideoNotFoundException();
-    let children =
+    const children =
       await this.videoRelationRepository.findChildrenByParentId(videoId);
 
     return children


### PR DESCRIPTION
[![NDD-417](https://badgen.net/badge/JIRA/NDD-417/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-417) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=the-NDD&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
비디오가 삭제되지 않는 버그가 있었음

# How
IDrive에 저장된 객체들을 삭제할 때 요청을 보내는 S3Client가 undefined로 설정되어서, 비디오 및 썸네일이 삭제되지 않았기에 이를 수정

# Result
정상적으로 비디오도 삭제되고, 썸네일과 비디오도 IDrive에서 모두 제거되는 것을 확인

[NDD-417]: https://milk717.atlassian.net/browse/NDD-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ