### PR TITLE
[NDD-420] Response DTO에서 createdAt을 number타입에서 파싱된 string으로 반환하게 수정

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,0 +1,4 @@
+export const parseDateToString = (date: Date) =>
+  `${date.getFullYear()}.${(date.getMonth() + 1)
+    .toString()
+    .padStart(2, '0')}.${date.getDate().toString().padStart(2, '0')}`;

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,4 +1,5 @@
-export const parseDateToString = (date: Date) =>
-  `${date.getFullYear()}.${(date.getMonth() + 1)
+export const parseDateToString = (date: Date) => {
+  return `${date.getFullYear()}.${(date.getMonth() + 1)
     .toString()
     .padStart(2, '0')}.${date.getDate().toString().padStart(2, '0')}`;
+};

--- a/src/video/dto/MemberVideoResponse.ts
+++ b/src/video/dto/MemberVideoResponse.ts
@@ -64,7 +64,7 @@ export class MemberVideoResponse {
       video.thumbnail,
       video.name,
       video.videoLength,
-      parseDateToString(member.createdAt),
+      parseDateToString(video.createdAt),
       member.nickname,
       member.profileImg,
     );

--- a/src/video/dto/MemberVideoResponse.ts
+++ b/src/video/dto/MemberVideoResponse.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Video } from '../entity/video';
 import { createPropertyOption } from 'src/util/swagger.util';
+import { parseDateToString } from 'src/util/util';
 
 export class MemberVideoResponse {
   @ApiProperty(createPropertyOption(1, '비디오 ID', Number))
@@ -23,8 +24,8 @@ export class MemberVideoResponse {
   @ApiProperty(createPropertyOption('03:00', '영상 길이', String))
   videoLength: string;
 
-  @ApiProperty(createPropertyOption(154515362, '영상 생성 일자', Number))
-  createdAt: number;
+  @ApiProperty(createPropertyOption('1998.09.05', '영상 생성 일자', Number))
+  createdAt: string;
 
   @ApiProperty(createPropertyOption('장아장', '회원 닉네임', String))
   nickname: string;
@@ -43,7 +44,7 @@ export class MemberVideoResponse {
     videoThumbnail: string,
     videoName: string,
     videoLength: string,
-    createdAt: number,
+    createdAt: string,
     nickname: string,
     userThumbnail: string,
   ) {
@@ -63,7 +64,7 @@ export class MemberVideoResponse {
       video.thumbnail,
       video.name,
       video.videoLength,
-      video.createdAt.getTime(),
+      parseDateToString(member.createdAt),
       member.nickname,
       member.profileImg,
     );

--- a/src/video/dto/RelatableVideoResponse.ts
+++ b/src/video/dto/RelatableVideoResponse.ts
@@ -12,7 +12,7 @@ export class RelatableVideoResponse {
   visibility: string;
   @ApiProperty(createPropertyOption('츄 직캠', '영상 이름', String))
   videoName: string;
-  @ApiProperty(createPropertyOption(13213210, '생성일자', Number))
+  @ApiProperty(createPropertyOption('1998.09.05', '생성일자', Number))
   createdAt: string;
 
   constructor(

--- a/src/video/dto/RelatableVideoResponse.ts
+++ b/src/video/dto/RelatableVideoResponse.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Video } from '../entity/video';
 import { createPropertyOption } from 'src/util/swagger.util';
+import { parseDateToString } from 'src/util/util';
 
 export class RelatableVideoResponse {
   @ApiProperty(createPropertyOption(1, '비디오 ID', Number))
@@ -12,14 +13,14 @@ export class RelatableVideoResponse {
   @ApiProperty(createPropertyOption('츄 직캠', '영상 이름', String))
   videoName: string;
   @ApiProperty(createPropertyOption(13213210, '생성일자', Number))
-  createdAt: number;
+  createdAt: string;
 
   constructor(
     id: number,
     isRelated: boolean,
     visibility: string,
     videoName: string,
-    createdAt: number,
+    createdAt: string,
   ) {
     this.id = id;
     this.isRelated = isRelated;
@@ -34,7 +35,7 @@ export class RelatableVideoResponse {
       isRelated,
       video.visibility,
       video.name,
-      video.createdAt.getTime(),
+      parseDateToString(video.createdAt),
     );
   }
 }

--- a/src/video/dto/singleVideoResponse.ts
+++ b/src/video/dto/singleVideoResponse.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { createPropertyOption } from 'src/util/swagger.util';
 import { Video } from '../entity/video';
+import { parseDateToString } from 'src/util/util';
 
 export class SingleVideoResponse {
   @ApiProperty(createPropertyOption(1, '비디오 ID', Number))
@@ -30,10 +31,8 @@ export class SingleVideoResponse {
   )
   readonly visibility: string;
 
-  @ApiProperty(
-    createPropertyOption(1699858790176, '비디오 생성 일자(ms 단위)', Number),
-  )
-  readonly createdAt: number;
+  @ApiProperty(createPropertyOption('1998.09.05', '영상 생성 일자', Number))
+  readonly createdAt: string;
 
   constructor(
     id: number,
@@ -41,7 +40,7 @@ export class SingleVideoResponse {
     videoName: string,
     videoLength: string,
     visibility: string,
-    createdAt: number,
+    createdAt: string,
   ) {
     this.id = id;
     this.thumbnail = thumbnail;
@@ -58,7 +57,7 @@ export class SingleVideoResponse {
       video.name,
       video.videoLength,
       video.visibility,
-      video.createdAt.getTime(),
+      parseDateToString(video.createdAt),
     );
   }
 }

--- a/src/video/dto/videoDetailResponse.ts
+++ b/src/video/dto/videoDetailResponse.ts
@@ -2,6 +2,7 @@ import { Video } from '../entity/video';
 import { ApiProperty } from '@nestjs/swagger';
 import { Member } from 'src/member/entity/member';
 import { createPropertyOption } from 'src/util/swagger.util';
+import { parseDateToString } from 'src/util/util';
 
 export class VideoDetailResponse {
   @ApiProperty(createPropertyOption(1, '비디오의 ID', Number))
@@ -33,10 +34,8 @@ export class VideoDetailResponse {
   @ApiProperty({ nullable: true })
   readonly hash: string;
 
-  @ApiProperty(
-    createPropertyOption(1699858790176, '비디오 생성 일자(ms 단위)', Number),
-  )
-  readonly createdAt: number;
+  @ApiProperty(createPropertyOption('1998.09.05', '영상 생성 일자', Number))
+  readonly createdAt: string;
 
   @ApiProperty(createPropertyOption('PUBLIC', '영상 공개여부', String))
   readonly visibility: string;
@@ -58,7 +57,7 @@ export class VideoDetailResponse {
     url: string,
     videoName: string,
     hash: string,
-    createdAt: number,
+    createdAt: string,
     visibility: string,
     thumbnail: string,
     videoAnswer: string,
@@ -83,7 +82,7 @@ export class VideoDetailResponse {
       video.url,
       video.name,
       hash,
-      video.createdAt.getTime(),
+      parseDateToString(video.createdAt),
       video.visibility,
       video.thumbnail,
       video.videoAnswer.toString(),


### PR DESCRIPTION
[![NDD-420](https://badgen.net/badge/JIRA/NDD-420/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-420) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=the-NDD&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

- 멘토님의 코멘트 : createdAt의 실제 데이터값을 주기보단, 이를 프론트엔드에서 바로 볼 수 있는 데이터로 파싱해서 주는 것이 정보가 더욱 안전할 것이라는 리뷰가 있었다. 

# How

- 해결 방안 : Date객체를 `yyyy.MM.DD`의 구조로 파싱하는 유틸함수를 두고, 이를 통해 createdAt이라는 Date값을 파싱해 반환토록 한다. 

# Result

<img width="265" alt="스크린샷 2024-02-07 15 29 20" src="https://github.com/the-NDD/Gomterview-BE/assets/99702271/7a7deb29-a264-41d4-9db5-d57e6f4766dc">


# Prize

- 프론트엔드에서 파싱해야 할 데이터 없이, 바로 출력하면 된다. 
  - 중간 파싱을 한다는 것은, 터미널이나 포스트맨등, 백엔드에 바로 요청을 보내는 방식으로 데이터가 외부에 노출될 수 있는 위험이 있다는 뜻이다. 

[jira](https://milk717.atlassian.net/browse/NDD-420)

[NDD-420]: https://milk717.atlassian.net/browse/NDD-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ