### PR TITLE
[ Event/Workbook ] Workbook 도메인의 카테고리 로직을 이벤트화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.1.1",
         "@nestjs/core": "^10.0.0",
+        "@nestjs/event-emitter": "^2.0.4",
         "@nestjs/jwt": "^10.1.1",
         "@nestjs/passport": "^10.0.2",
         "@nestjs/platform-express": "^10.2.10",
@@ -2667,6 +2668,18 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/event-emitter": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/event-emitter/-/event-emitter-2.0.4.tgz",
+      "integrity": "sha512-quMiw8yOwoSul0pp3mOonGz8EyXWHSBTqBy8B0TbYYgpnG1Ix2wGUnuTksLWaaBiiOTDhciaZ41Y5fJZsSJE1Q==",
+      "dependencies": {
+        "eventemitter2": "6.4.9"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@nestjs/jwt": {
@@ -6878,6 +6891,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -7353,9 +7371,9 @@
       "peer": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -8093,10 +8111,24 @@
         "ioredis": "^5"
       }
     },
-    "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true,
       "optional": true
     },
@@ -9039,6 +9071,13 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -11607,17 +11646,17 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.3.tgz",
+      "integrity": "sha512-vfuYK48HXCTFD03G/1/zkIls3Ebr2YNa4qU9gHDZdblHLiqhJrJGkY3+0Nx0JpN9qBhJbVObc1CNciT1bIZJxw==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/event-emitter": "^2.0.4",
     "@nestjs/jwt": "^10.1.1",
     "@nestjs/passport": "^10.0.2",
     "@nestjs/platform-express": "^10.2.10",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,9 +21,11 @@ import { WorkbookModule } from './workbook/workbook.module';
 import { MulterModule } from '@nestjs/platform-express';
 import { Workbook } from './workbook/entity/workbook';
 import { HealthModule } from './health/health.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
+    EventEmitterModule.forRoot(),
     TypeOrmModule.forRootAsync(MYSQL_OPTION),
     TypeOrmModule.forFeature([Category, Member, Question, Answer, Workbook]),
     MulterModule.register({

--- a/src/category/service/category.service.ts
+++ b/src/category/service/category.service.ts
@@ -2,6 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { CategoryRepository } from '../repository/category.repository';
 import { CategoryResponse } from '../dto/categoryResponse';
 import { Transactional } from 'typeorm-transactional';
+import { OnEvent } from '@nestjs/event-emitter';
+import { isEmpty } from '@nestjs/class-validator';
+import { CategoryNotFoundException } from '../exception/category.exception';
 
 @Injectable()
 export class CategoryService {
@@ -12,5 +15,11 @@ export class CategoryService {
     const categories = await this.categoryRepository.findAll();
 
     return categories.map(CategoryResponse.from);
+  }
+
+  @OnEvent('category.validate')
+  async validateExistence(categoryId: number) {
+    const category = await this.categoryRepository.findByCategoryId(categoryId);
+    if (isEmpty(category)) throw new CategoryNotFoundException();
   }
 }

--- a/src/category/service/category.service.ts
+++ b/src/category/service/category.service.ts
@@ -17,7 +17,9 @@ export class CategoryService {
     return categories.map(CategoryResponse.from);
   }
 
-  @OnEvent('category.validate')
+  @OnEvent('category.validate', {
+    suppressErrors: false,
+  })
   async validateExistence(categoryId: number) {
     const category = await this.categoryRepository.findByCategoryId(categoryId);
     if (isEmpty(category)) throw new CategoryNotFoundException();

--- a/src/member/repository/member.repository.ts
+++ b/src/member/repository/member.repository.ts
@@ -31,4 +31,8 @@ export class MemberRepository {
   async query(query: string) {
     return await this.memberRepository.query(query);
   }
+
+  async remove(member: Member) {
+    await this.memberRepository.remove(member);
+  }
 }

--- a/src/member/service/member.service.ts
+++ b/src/member/service/member.service.ts
@@ -2,13 +2,9 @@ import { Injectable } from '@nestjs/common';
 import { Request } from 'express';
 import { TokenService } from 'src/token/service/token.service';
 import { MemberRepository } from '../repository/member.repository';
-import { getTokenValue, validateManipulatedToken } from 'src/util/token.util';
+import { getTokenValue } from 'src/util/token.util';
 import { MemberNicknameResponse } from '../dto/memberNicknameResponse';
 import { companies } from 'src/constant/constant';
-import { OAuthRequest } from 'src/auth/interface/auth.interface';
-import { Member } from '../entity/member';
-import { OnEvent } from '@nestjs/event-emitter';
-import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
 
 @Injectable()
 export class MemberService {
@@ -33,22 +29,5 @@ export class MemberService {
     const randomCompany =
       companies[Math.floor(Math.random() * companies.length)];
     return `${randomCompany} 최종 면접에 들어온 ${nickname}`;
-  }
-
-  @OnEvent('member.create')
-  async createMember(oauthRequest: OAuthRequest) {
-    let member = new Member(
-      null,
-      oauthRequest.email,
-      oauthRequest.name,
-      oauthRequest.img,
-      new Date(),
-    );
-    await this.memberRepository.save(member);
-  }
-
-  @OnEvent('member.manipulated')
-  async validateManipulatedToken(member: Member) {
-    if (!member) throw new ManipulatedTokenNotFiltered();
   }
 }

--- a/src/member/service/member.service.ts
+++ b/src/member/service/member.service.ts
@@ -2,9 +2,13 @@ import { Injectable } from '@nestjs/common';
 import { Request } from 'express';
 import { TokenService } from 'src/token/service/token.service';
 import { MemberRepository } from '../repository/member.repository';
-import { getTokenValue } from 'src/util/token.util';
+import { getTokenValue, validateManipulatedToken } from 'src/util/token.util';
 import { MemberNicknameResponse } from '../dto/memberNicknameResponse';
 import { companies } from 'src/constant/constant';
+import { OAuthRequest } from 'src/auth/interface/auth.interface';
+import { Member } from '../entity/member';
+import { OnEvent } from '@nestjs/event-emitter';
+import { ManipulatedTokenNotFiltered } from 'src/token/exception/token.exception';
 
 @Injectable()
 export class MemberService {
@@ -29,5 +33,22 @@ export class MemberService {
     const randomCompany =
       companies[Math.floor(Math.random() * companies.length)];
     return `${randomCompany} 최종 면접에 들어온 ${nickname}`;
+  }
+
+  @OnEvent('member.create')
+  async createMember(oauthRequest: OAuthRequest) {
+    let member = new Member(
+      null,
+      oauthRequest.email,
+      oauthRequest.name,
+      oauthRequest.img,
+      new Date(),
+    );
+    await this.memberRepository.save(member);
+  }
+
+  @OnEvent('member.manipulated')
+  async validateManipulatedToken(member: Member) {
+    if (!member) throw new ManipulatedTokenNotFiltered();
   }
 }

--- a/src/util/test.util.ts
+++ b/src/util/test.util.ts
@@ -19,10 +19,12 @@ import { Question } from '../question/entity/question';
 import { Answer } from '../answer/entity/answer';
 import { Video } from '../video/entity/video';
 import { VideoRelation } from 'src/video/entity/videoRelation';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 export const createIntegrationTestModule = async (modules: unknown[]) => {
   const ormModule = await createTypeOrmModuleForTest();
   modules.push(ormModule);
+  modules.push(EventEmitterModule.forRoot());
 
   return await Test.createTestingModule({
     imports: modules as DynamicModule[],

--- a/src/video/fixture/video.fixture.ts
+++ b/src/video/fixture/video.fixture.ts
@@ -1,4 +1,4 @@
-import { PRIVATE, PUBLIC } from '../constant/videoVisibility';
+import { LINK_ONLY, PRIVATE, PUBLIC } from '../constant/videoVisibility';
 import { CreateVideoRequest } from '../dto/createVideoRequest';
 import { UpdateVideoIndexRequest } from '../dto/updateVideoIndexRequest';
 import { Video } from '../entity/video';
@@ -85,6 +85,18 @@ export const videoFixture = new Video(
   'https://thumbnail-test.com',
   '03:29',
   PUBLIC,
+  '예시 답변입니다.',
+);
+
+export const linkOnlyVideoFixture = new Video(
+  1,
+  1,
+  1,
+  '루이뷔통통튀기네',
+  'https://test.com',
+  'https://thumbnail-test.com',
+  '03:29',
+  LINK_ONLY,
   '예시 답변입니다.',
 );
 

--- a/src/workbook/dto/workbookResponse.ts
+++ b/src/workbook/dto/workbookResponse.ts
@@ -60,7 +60,7 @@ export class WorkbookResponse {
     const member = workbook.member;
     return new WorkbookResponse(
       workbook.id,
-      workbook.category.id,
+      workbook.categoryId,
       member.nickname,
       member.profileImg,
       workbook.copyCount,

--- a/src/workbook/entity/workbook.ts
+++ b/src/workbook/entity/workbook.ts
@@ -3,10 +3,11 @@ import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 import { Member } from '../../member/entity/member';
 import { Category } from '../../category/entity/category';
 import { UpdateWorkbookRequest } from '../dto/updateWorkbookRequest';
+import { CreateWorkbookRequest } from '../dto/createWorkbookRequest';
 
 @Entity({ name: 'Workbook' })
 @Index('idx_isPublic', ['isPublic'])
-@Index('idx_isPublic_categoryId', ['isPublic', 'category'])
+@Index('idx_isPublic_categoryId', ['isPublic', 'categoryId'])
 export class Workbook extends DefaultEntity {
   @Column()
   title: string;
@@ -14,9 +15,8 @@ export class Workbook extends DefaultEntity {
   @Column({ type: 'blob', nullable: true })
   content: string;
 
-  @ManyToOne(() => Category)
-  @JoinColumn({ name: 'category' })
-  category: Category;
+  @Column({ name: 'category' })
+  categoryId: number;
 
   @Column()
   copyCount: number;
@@ -33,7 +33,7 @@ export class Workbook extends DefaultEntity {
     createdAt: Date,
     title: string,
     content: string,
-    category: Category,
+    categoryId: number,
     copyCount: number,
     member: Member,
     isPublic: boolean,
@@ -41,7 +41,7 @@ export class Workbook extends DefaultEntity {
     super(id, createdAt);
     this.title = title;
     this.content = content;
-    this.category = category;
+    this.categoryId = categoryId;
     this.copyCount = copyCount;
     this.member = member;
     this.isPublic = isPublic;
@@ -59,10 +59,26 @@ export class Workbook extends DefaultEntity {
       new Date(),
       title,
       content,
-      category,
+      category.id,
       0,
       member,
       isPublic,
+    );
+  }
+
+  static from(
+    createWorkbookRequest: CreateWorkbookRequest,
+    member: Member,
+  ): Workbook {
+    return new Workbook(
+      null,
+      new Date(),
+      createWorkbookRequest.title,
+      createWorkbookRequest.content,
+      createWorkbookRequest.categoryId,
+      0,
+      member,
+      createWorkbookRequest.isPublic,
     );
   }
 
@@ -77,7 +93,7 @@ export class Workbook extends DefaultEntity {
   updateInfo(updateWorkbookRequest: UpdateWorkbookRequest, category: Category) {
     this.title = updateWorkbookRequest.title;
     this.content = updateWorkbookRequest.content;
-    this.category = category;
+    this.categoryId = category.id;
     this.isPublic = updateWorkbookRequest.isPublic;
   }
 }

--- a/src/workbook/entity/workbook.ts
+++ b/src/workbook/entity/workbook.ts
@@ -90,10 +90,10 @@ export class Workbook extends DefaultEntity {
     this.copyCount++;
   }
 
-  updateInfo(updateWorkbookRequest: UpdateWorkbookRequest, category: Category) {
+  updateInfo(updateWorkbookRequest: UpdateWorkbookRequest) {
     this.title = updateWorkbookRequest.title;
     this.content = updateWorkbookRequest.content;
-    this.categoryId = category.id;
+    this.categoryId = updateWorkbookRequest.categoryId;
     this.isPublic = updateWorkbookRequest.isPublic;
   }
 }

--- a/src/workbook/fixture/workbook.fixture.ts
+++ b/src/workbook/fixture/workbook.fixture.ts
@@ -28,7 +28,7 @@ export const workbookFixtureWithId = new Workbook(
   new Date(),
   '테스트 문제집',
   '테스트로 만드는 문제집입니다.',
-  categoryFixtureWithId,
+  categoryFixtureWithId.id,
   0,
   memberFixture,
   true,

--- a/src/workbook/repository/workbook.repository.ts
+++ b/src/workbook/repository/workbook.repository.ts
@@ -31,7 +31,6 @@ export class WorkbookRepository {
   async findAll() {
     return this.repository
       .createQueryBuilder('Workbook')
-      .leftJoinAndSelect('Workbook.category', 'category')
       .leftJoinAndSelect('Workbook.member', 'member')
       .where('Workbook.isPublic = :state', { state: true })
       .orderBy('Workbook.copyCount', 'DESC')
@@ -42,9 +41,8 @@ export class WorkbookRepository {
     return this.repository
       .createQueryBuilder('Workbook')
       .leftJoinAndSelect('Workbook.member', 'member')
-      .leftJoinAndSelect('Workbook.category', 'category')
       .where('Workbook.isPublic = :state', { state: true })
-      .andWhere('category.id = :categoryId', { categoryId })
+      .andWhere('workbook.category = :categoryId', { categoryId })
       .orderBy('Workbook.copyCount', 'DESC')
       .getMany();
   }
@@ -72,7 +70,6 @@ export class WorkbookRepository {
     return await this.repository
       .createQueryBuilder('Workbook')
       .leftJoinAndSelect('Workbook.member', 'member')
-      .leftJoinAndSelect('Workbook.category', 'category')
       .where('Workbook.id = :id', { id })
       .getOne();
   }

--- a/src/workbook/service/workbook.service.spec.ts
+++ b/src/workbook/service/workbook.service.spec.ts
@@ -166,9 +166,7 @@ describe('WorkbookService 단위테스트', () => {
       //given
 
       //when
-      mockCategoryRepository.findByCategoryId.mockResolvedValue(
-        categoryFixtureWithId,
-      );
+      mockEmitter.emitAsync.mockResolvedValue(undefined);
       mockWorkbookRepository.findAllByCategoryId.mockResolvedValue([
         workbookFixture,
       ]);
@@ -188,6 +186,7 @@ describe('WorkbookService 단위테스트', () => {
       mockWorkbookRepository.findAllByCategoryId.mockResolvedValue([
         workbookFixture,
       ]);
+      mockEmitter.emitAsync.mockRejectedValue(new CategoryNotFoundException());
       //then
       await expect(service.findWorkbooks(1234)).rejects.toThrow(
         new CategoryNotFoundException(),
@@ -263,9 +262,7 @@ describe('WorkbookService 단위테스트', () => {
       //given
 
       //when
-      mockCategoryRepository.findByCategoryId.mockResolvedValue(
-        categoryFixtureWithId,
-      );
+      mockEmitter.emitAsync.mockResolvedValue(undefined);
       mockWorkbookRepository.findById.mockResolvedValue(workbookFixture);
 
       //then
@@ -287,6 +284,7 @@ describe('WorkbookService 단위테스트', () => {
         categoryFixtureWithId,
       );
       mockWorkbookRepository.findById.mockResolvedValue(workbookFixture);
+      mockEmitter.emitAsync.mockResolvedValue(undefined);
       const workbookUpdateRequest = new UpdateWorkbookRequest(
         workbookFixture.id,
         'newT',

--- a/src/workbook/service/workbook.service.spec.ts
+++ b/src/workbook/service/workbook.service.spec.ts
@@ -45,10 +45,6 @@ import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
 describe('WorkbookService 단위테스트', () => {
   let module: TestingModule;
   let service: WorkbookService;
-
-  const mockCategoryRepository = {
-    findByCategoryId: jest.fn(),
-  };
   const mockWorkbookRepository = {
     save: jest.fn(),
     findById: jest.fn(),
@@ -74,15 +70,8 @@ describe('WorkbookService 단위테스트', () => {
   beforeAll(async () => {
     module = await Test.createTestingModule({
       imports: [await createTypeOrmModuleForTest()],
-      providers: [
-        WorkbookService,
-        CategoryRepository,
-        WorkbookRepository,
-        EventEmitter2,
-      ],
+      providers: [WorkbookService, WorkbookRepository, EventEmitter2],
     })
-      .overrideProvider(CategoryRepository)
-      .useValue(mockCategoryRepository)
       .overrideProvider(WorkbookRepository)
       .useValue(mockWorkbookRepository)
       .overrideProvider(EventEmitter2)
@@ -102,9 +91,6 @@ describe('WorkbookService 단위테스트', () => {
       //given
 
       //when
-      mockCategoryRepository.findByCategoryId.mockResolvedValue(
-        categoryFixtureWithId,
-      );
       mockWorkbookRepository.insert.mockResolvedValue(workbookInsertResult);
 
       //then
@@ -136,9 +122,6 @@ describe('WorkbookService 단위테스트', () => {
       //given
 
       //when
-      mockCategoryRepository.findByCategoryId.mockResolvedValue(
-        categoryFixtureWithId,
-      );
       mockWorkbookRepository.insert.mockResolvedValue(workbookFixtureWithId);
 
       //then
@@ -182,7 +165,6 @@ describe('WorkbookService 단위테스트', () => {
       //given
 
       //when
-      mockCategoryRepository.findByCategoryId.mockResolvedValue(null);
       mockWorkbookRepository.findAllByCategoryId.mockResolvedValue([
         workbookFixture,
       ]);
@@ -280,9 +262,6 @@ describe('WorkbookService 단위테스트', () => {
       //given
 
       //when
-      mockCategoryRepository.findByCategoryId.mockResolvedValue(
-        categoryFixtureWithId,
-      );
       mockWorkbookRepository.findById.mockResolvedValue(workbookFixture);
       mockEmitter.emitAsync.mockResolvedValue(undefined);
       const workbookUpdateRequest = new UpdateWorkbookRequest(

--- a/src/workbook/service/workbook.service.ts
+++ b/src/workbook/service/workbook.service.ts
@@ -18,7 +18,6 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 export class WorkbookService {
   constructor(
     private readonly workbookRepository: WorkbookRepository,
-    private readonly categoryRepository: CategoryRepository,
     readonly emitter: EventEmitter2,
   ) {}
 

--- a/src/workbook/service/workbook.service.ts
+++ b/src/workbook/service/workbook.service.ts
@@ -12,12 +12,14 @@ import { validateWorkbook, validateWorkbookOwner } from '../util/workbook.util';
 import { WorkbookTitleResponse } from '../dto/workbookTitleResponse';
 import { UpdateWorkbookRequest } from '../dto/updateWorkbookRequest';
 import { Transactional } from 'typeorm-transactional';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 @Injectable()
 export class WorkbookService {
   constructor(
     private workbookRepository: WorkbookRepository,
     private categoryRepository: CategoryRepository,
+    private emitter: EventEmitter2,
   ) {}
 
   @Transactional()
@@ -119,5 +121,9 @@ export class WorkbookService {
     validateWorkbook(workbook);
     validateWorkbookOwner(workbook, member);
     await this.workbookRepository.remove(workbook);
+  }
+
+  async validateCategoryExistence(categoryId: number) {
+    await this.emitter.emitAsync('category.validate', categoryId);
   }
 }

--- a/src/workbook/service/workbook.service.ts
+++ b/src/workbook/service/workbook.service.ts
@@ -17,9 +17,9 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 @Injectable()
 export class WorkbookService {
   constructor(
-    private workbookRepository: WorkbookRepository,
-    private categoryRepository: CategoryRepository,
-    private emitter: EventEmitter2,
+    private readonly workbookRepository: WorkbookRepository,
+    private readonly categoryRepository: CategoryRepository,
+    readonly emitter: EventEmitter2,
   ) {}
 
   @Transactional()
@@ -27,20 +27,12 @@ export class WorkbookService {
     createWorkbookRequest: CreateWorkbookRequest,
     member: Member,
   ) {
-    const category = await this.categoryRepository.findByCategoryId(
-      createWorkbookRequest.categoryId,
-    );
     validateManipulatedToken(member);
-    validateCategory(category);
+    await this.validateCategoryExistence(createWorkbookRequest.categoryId);
 
-    const workbook = Workbook.of(
-      createWorkbookRequest.title,
-      createWorkbookRequest.content,
-      category,
-      member,
-      createWorkbookRequest.isPublic,
-    );
+    const workbook = Workbook.from(createWorkbookRequest, member);
     const result = await this.workbookRepository.insert(workbook);
+    console.log(result);
     return result.identifiers[0].id as number;
   }
 

--- a/src/workbook/service/workbook.service.ts
+++ b/src/workbook/service/workbook.service.ts
@@ -51,8 +51,7 @@ export class WorkbookService {
   }
 
   private async findAllByCategory(categoryId: number) {
-    const category = await this.categoryRepository.findByCategoryId(categoryId);
-    validateCategory(category);
+    await this.validateCategoryExistence(categoryId);
 
     const workbooks =
       await this.workbookRepository.findAllByCategoryId(categoryId);
@@ -87,20 +86,16 @@ export class WorkbookService {
     updateWorkbookRequest: UpdateWorkbookRequest,
     member: Member,
   ) {
-    const category = await this.categoryRepository.findByCategoryId(
-      updateWorkbookRequest.categoryId,
-    );
-    validateManipulatedToken(member);
-    validateCategory(category);
+    await this.validateCategoryExistence(updateWorkbookRequest.categoryId);
 
     const workbook = await this.workbookRepository.findById(
       updateWorkbookRequest.workbookId,
     );
-
+    validateManipulatedToken(member);
     validateWorkbook(workbook);
     validateWorkbookOwner(workbook, member);
 
-    workbook.updateInfo(updateWorkbookRequest, category);
+    workbook.updateInfo(updateWorkbookRequest);
     await this.workbookRepository.update(workbook);
     return WorkbookResponse.of(workbook);
   }

--- a/src/workbook/workbook.module.ts
+++ b/src/workbook/workbook.module.ts
@@ -4,24 +4,12 @@ import { Workbook } from './entity/workbook';
 import { WorkbookRepository } from './repository/workbook.repository';
 import { WorkbookService } from './service/workbook.service';
 import { WorkbookController } from './controller/workbook.controller';
-import { Category } from '../category/entity/category';
-import { CategoryRepository } from '../category/repository/category.repository';
-import { CategoryModule } from '../category/category.module';
 import { TokenSoftGuard } from '../token/guard/token.soft.guard';
 import { TokenModule } from '../token/token.module';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([Workbook, Category]),
-    CategoryModule,
-    TokenModule,
-  ],
-  providers: [
-    WorkbookRepository,
-    WorkbookService,
-    CategoryRepository,
-    TokenSoftGuard,
-  ],
+  imports: [TypeOrmModule.forFeature([Workbook]), TokenModule],
+  providers: [WorkbookRepository, WorkbookService, TokenSoftGuard],
   controllers: [WorkbookController],
 })
 export class WorkbookModule {}


### PR DESCRIPTION
<!-- [NDD-22]: PR 제목 (실제소요시간h / 스토리포인트h) -->
<!-- 사용하지 않는 템플릿 제목은 삭제합니다 -->

# Why

왜 @JoinColumn을 제거했는가?
- 직접 연관을 통해 데이터를 조회하는 과정은 편하게 사용할 수 있다는 장점이 있었다. 
- 하지만, 리펙토링 과정에서 로직의 복잡성을 증가시키며, 도메인의 독립성을 제한한다. 
- 협력을 하는 것은 좋지만, 각 도메인이 하는 일들을 독립시켜야 할 필요가 있었다. 
- 다른 도메인과의 협력을 이벤트로 처리하는 방식으로 수정하게 되었다. 

# How

<img width="343" alt="스크린샷 2024-02-14 16 35 31" src="https://github.com/the-NDD/Gomterview-BE/assets/99702271/55f366ec-24bc-4c24-9918-f9cc2f3a33a9">

- nestjs의 event emitter를 통한 애플리케이션 전역의 이벤트를 처리하게 했다. 
- 문제집 비즈니스 로직
  - category id를 이용해 해당 카테고리가 존재하는지 검증하는 부분은 `category.service.ts`로 옮겨 `@OnEvent()`로 처리하게 했다.
  - 이 때 예외 발생시의 처리는 `suppressErrors: false`옵션을 주어 처리했다. 
    - 해당 옵션은 이벤트가 발생할 때, 예외를 이벤트 발생 로직에 전파시켜준다. 

# Result

<img width="262" alt="스크린샷 2024-02-14 16 38 25" src="https://github.com/the-NDD/Gomterview-BE/assets/99702271/e15e4b30-f5d2-462d-89ae-03fef764fae6">


# Prize

<img width="523" alt="스크린샷 2024-02-14 16 38 51" src="https://github.com/the-NDD/Gomterview-BE/assets/99702271/857d5a58-5f1e-404c-848e-557be3326c9a">

- Workbook모듈에서 Category의 import와 Repository사용을 제거할 수 있었다.

# Reference

[nestjs-event관련 문서](https://docs.nestjs.com/techniques/events)