### PR TITLE
[ Event/answer] Answer도메인 분리/이벤트 기반으로 로직을 수행하게 수정

### DIFF
--- a/src/answer/answer.module.ts
+++ b/src/answer/answer.module.ts
@@ -6,31 +6,17 @@ import { AnswerRepository } from './repository/answer.repository';
 import { Question } from '../question/entity/question';
 import { AnswerService } from './service/answer.service';
 import { AnswerController } from './controller/answer.controller';
-import { QuestionRepository } from '../question/repository/question.repository';
-import { QuestionModule } from '../question/question.module';
-import { CategoryRepository } from '../category/repository/category.repository';
-import { CategoryModule } from '../category/category.module';
 import { Category } from '../category/entity/category';
 import { Workbook } from '../workbook/entity/workbook';
-import { WorkbookRepository } from '../workbook/repository/workbook.repository';
-import { WorkbookModule } from '../workbook/workbook.module';
 import { TokenModule } from 'src/token/token.module';
+import { AnswerEventHandler } from './service/answer.event.handler';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Member, Answer, Question, Category, Workbook]),
-    QuestionModule,
-    CategoryModule,
-    WorkbookModule,
     TokenModule,
   ],
-  providers: [
-    AnswerRepository,
-    AnswerService,
-    QuestionRepository,
-    CategoryRepository,
-    WorkbookRepository,
-  ],
+  providers: [AnswerRepository, AnswerService, AnswerEventHandler],
   controllers: [AnswerController],
 })
 export class AnswerModule {}

--- a/src/answer/controller/answer.controller.spec.ts
+++ b/src/answer/controller/answer.controller.spec.ts
@@ -254,7 +254,7 @@ describe('AnswerController 통합테스트', () => {
         Question.of(workbook.id, null, 'testQuestion'),
       );
       const answer = await answerRepository.save(
-        Answer.of('test', member, question),
+        Answer.of('test', member, question.id),
       );
       //when&then
       const token = await authService.login(memberFixturesOAuthRequest);
@@ -275,7 +275,7 @@ describe('AnswerController 통합테스트', () => {
         Question.of(workbook.id, null, 'testQuestion'),
       );
       const answer = await answerRepository.save(
-        Answer.of('test', member, question),
+        Answer.of('test', member, question.id),
       );
 
       //when&then
@@ -295,7 +295,7 @@ describe('AnswerController 통합테스트', () => {
         Question.of(workbook.id, null, 'testQuestion'),
       );
       const answer = await answerRepository.save(
-        Answer.of('test', member, question),
+        Answer.of('test', member, question.id),
       );
 
       //when&then
@@ -317,7 +317,7 @@ describe('AnswerController 통합테스트', () => {
         Question.of(workbook.id, null, 'testQuestion'),
       );
       const answer = await answerRepository.save(
-        Answer.of('test', member, question),
+        Answer.of('test', member, question.id),
       );
 
       //when&then
@@ -361,7 +361,7 @@ describe('AnswerController 통합테스트', () => {
       );
       for (let index = 1; index <= 10; index++) {
         await answerRepository.save(
-          Answer.of(`test${index}`, member, question),
+          Answer.of(`test${index}`, member, question.id),
         );
       }
 
@@ -383,13 +383,13 @@ describe('AnswerController 통합테스트', () => {
         Question.of(workbook.id, null, 'testQuestion'),
       );
       const answer = await answerRepository.save(
-        Answer.of('test', member, question),
+        Answer.of('test', member, question.id),
       );
       question.setDefaultAnswer(answer);
       await questionRepository.save(question);
       for (let index = 1; index <= 10; index++) {
         await answerRepository.save(
-          Answer.of(`test${index}`, member, question),
+          Answer.of(`test${index}`, member, question.id),
         );
       }
 
@@ -412,7 +412,7 @@ describe('AnswerController 통합테스트', () => {
       );
       for (let index = 1; index <= 10; index++) {
         await answerRepository.save(
-          Answer.of(`test${index}`, member, question),
+          Answer.of(`test${index}`, member, question.id),
         );
       }
 
@@ -436,7 +436,7 @@ describe('AnswerController 통합테스트', () => {
         Question.of(workbook.id, null, 'testQuestion'),
       );
       const answer = await answerRepository.save(
-        Answer.of('test', member, question),
+        Answer.of('test', member, question.id),
       );
 
       //when&then
@@ -457,7 +457,7 @@ describe('AnswerController 통합테스트', () => {
         Question.of(workbook.id, null, 'testQuestion'),
       );
       const answer = await answerRepository.save(
-        Answer.of('test', member, question),
+        Answer.of('test', member, question.id),
       );
 
       //when&then
@@ -474,7 +474,7 @@ describe('AnswerController 통합테스트', () => {
         Question.of(workbook.id, null, 'testQuestion'),
       );
       const answer = await answerRepository.save(
-        Answer.of('test', member, question),
+        Answer.of('test', member, question.id),
       );
 
       //when&then

--- a/src/answer/entity/answer.ts
+++ b/src/answer/entity/answer.ts
@@ -34,4 +34,8 @@ export class Answer extends DefaultEntity {
   isOwnedBy(member: Member) {
     return this.member.id === member.id;
   }
+
+  updateQuestionId(questionId: number) {
+    this.questionId = questionId;
+  }
 }

--- a/src/answer/entity/answer.ts
+++ b/src/answer/entity/answer.ts
@@ -1,7 +1,6 @@
 import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { DefaultEntity } from '../../app.entity';
 import { Member } from '../../member/entity/member';
-import { Question } from '../../question/entity/question';
 
 @Entity({ name: 'Answer' })
 export class Answer extends DefaultEntity {
@@ -12,25 +11,24 @@ export class Answer extends DefaultEntity {
   @JoinColumn()
   member: Member;
 
-  @ManyToOne(() => Question, { onDelete: 'CASCADE' })
-  @JoinColumn()
-  question: Question;
+  @Column({ name: 'question' })
+  questionId: number;
 
   constructor(
     id: number,
     createdAt: Date,
     content: string,
     member: Member,
-    question: Question,
+    questionId: number,
   ) {
     super(id, createdAt);
     this.content = content;
     this.member = member;
-    this.question = question;
+    this.questionId = questionId;
   }
 
-  static of(content: string, member: Member, question: Question) {
-    return new Answer(null, new Date(), content, member, question);
+  static of(content: string, member: Member, questionId: number) {
+    return new Answer(null, new Date(), content, member, questionId);
   }
 
   isOwnedBy(member: Member) {

--- a/src/answer/event/clear.default.answer.event.ts
+++ b/src/answer/event/clear.default.answer.event.ts
@@ -1,0 +1,13 @@
+export class ClearDefaultAnswerEvent {
+  static readonly MESSAGE = 'question.clear.default.answer';
+
+  readonly answerId: number;
+
+  constructor(answerId: number) {
+    this.answerId = answerId;
+  }
+
+  static of(answerId: number) {
+    return new ClearDefaultAnswerEvent(answerId);
+  }
+}

--- a/src/answer/event/update.answer.origin.event.ts
+++ b/src/answer/event/update.answer.origin.event.ts
@@ -1,0 +1,15 @@
+export class UpdateAnswersOriginEvent {
+  static readonly MESSAGE = 'answer.update.origin';
+
+  readonly questionId: number;
+  readonly answerId: number;
+
+  constructor(questionId: number, answerId: number) {
+    this.questionId = questionId;
+    this.answerId = answerId;
+  }
+
+  static of(questionId: number, answerId: number) {
+    return new UpdateAnswersOriginEvent(questionId, answerId);
+  }
+}

--- a/src/answer/fixture/answer.fixture.ts
+++ b/src/answer/fixture/answer.fixture.ts
@@ -7,7 +7,7 @@ import { DefaultAnswerRequest } from '../dto/defaultAnswerRequest';
 export const answerFixture = Answer.of(
   'testContent',
   memberFixture,
-  questionFixture,
+  questionFixture.id,
 );
 
 export const createAnswerRequestFixture = new CreateAnswerRequest(

--- a/src/answer/repository/answer.repository.ts
+++ b/src/answer/repository/answer.repository.ts
@@ -26,7 +26,7 @@ export class AnswerRepository {
     return await this.repository.findOneBy({
       content: content,
       member: { id: memberId },
-      question: { id: questionId },
+      questionId: questionId,
     });
   }
 
@@ -34,8 +34,7 @@ export class AnswerRepository {
     return this.repository
       .createQueryBuilder('answer')
       .leftJoinAndSelect('answer.member', 'member')
-      .leftJoinAndSelect('answer.question', 'question')
-      .where('question.id = :questionId', { questionId })
+      .where('answer.question = :questionId', { questionId })
       .orderBy('answer.createdAt', 'DESC')
       .getMany();
   }

--- a/src/answer/repository/answer.repository.ts
+++ b/src/answer/repository/answer.repository.ts
@@ -39,6 +39,10 @@ export class AnswerRepository {
       .getMany();
   }
 
+  async update(answer: Answer) {
+    await this.repository.update(answer.id, answer);
+  }
+
   async remove(answer: Answer) {
     await this.repository.remove(answer);
   }

--- a/src/answer/repository/answer.repository.ts
+++ b/src/answer/repository/answer.repository.ts
@@ -39,6 +39,17 @@ export class AnswerRepository {
       .getMany();
   }
 
+  async findAllByQuestionOriginId(questionId: number) {
+    return this.repository
+      .createQueryBuilder('answer')
+      .leftJoinAndSelect('answer.member', 'member')
+      .leftJoinAndSelect('answer.question', 'question')
+      .where('answer.question = question.origin.id')
+      .where('answer.question = :questionId', { questionId })
+      .orderBy('answer.createdAt', 'DESC')
+      .getMany();
+  }
+
   async update(answer: Answer) {
     await this.repository.update(answer.id, answer);
   }

--- a/src/answer/repository/answer.repository.ts
+++ b/src/answer/repository/answer.repository.ts
@@ -39,17 +39,6 @@ export class AnswerRepository {
       .getMany();
   }
 
-  async findAllByQuestionOriginId(questionId: number) {
-    return this.repository
-      .createQueryBuilder('answer')
-      .leftJoinAndSelect('answer.member', 'member')
-      .leftJoinAndSelect('answer.question', 'question')
-      .where('answer.question = question.origin.id')
-      .where('answer.question = :questionId', { questionId })
-      .orderBy('answer.createdAt', 'DESC')
-      .getMany();
-  }
-
   async update(answer: Answer) {
     await this.repository.update(answer.id, answer);
   }

--- a/src/answer/service/answer.event.handler.ts
+++ b/src/answer/service/answer.event.handler.ts
@@ -11,6 +11,7 @@ import { Member } from 'src/member/entity/member';
 import { FindQuestionToValidateWorkbookOwnership } from 'src/question/event/find.question.to.validate.workbook.ownership.event';
 import { CheckQuestionToBeOriginEvent } from 'src/question/event/check.question.tobe.origin.event';
 import { ValidateDefaultAnswersExistenceEvent } from 'src/question/event/validate.default.answers.existence.event';
+import { ClearDefaultAnswerEvent } from '../event/clear.default.answer.event';
 
 @Injectable()
 export class AnswerEventHandler {
@@ -71,5 +72,10 @@ export class AnswerEventHandler {
       ValidateDefaultAnswersExistenceEvent.MESSAGE,
       event,
     );
+  }
+
+  async clearDefaultAnswer(answerId: number) {
+    const event = ClearDefaultAnswerEvent.of(answerId);
+    await this.emitter.emitAsync(ClearDefaultAnswerEvent.MESSAGE, event);
   }
 }

--- a/src/answer/service/answer.event.handler.ts
+++ b/src/answer/service/answer.event.handler.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@nestjs/common';
+import { AnswerRepository } from '../repository/answer.repository';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import { UpdateAnswersOriginEvent } from '../event/update.answer.origin.event';
+import { FindQuestionOriginEvent } from 'src/question/event/find.question.origin.event';
+import { ValidateQuestionExistenceEvent } from 'src/question/event/validate.question.existence.event';
+import { ValidateQuestionOriginEvent } from 'src/question/event/validate.question.origin.event';
+import { UpdateDefaultAnswerEvent } from 'src/question/event/update.default.answer.event';
+import { Answer } from '../entity/answer';
+import { Member } from 'src/member/entity/member';
+import { FindQuestionToValidateWorkbookOwnership } from 'src/question/event/find.question.to.validate.workbook.ownership.event';
+import { CheckQuestionToBeOriginEvent } from 'src/question/event/check.question.tobe.origin.event';
+import { ValidateDefaultAnswersExistenceEvent } from 'src/question/event/validate.default.answers.existence.event';
+
+@Injectable()
+export class AnswerEventHandler {
+  constructor(
+    private answerRepository: AnswerRepository,
+    private emitter: EventEmitter2,
+  ) {}
+
+  @OnEvent(UpdateAnswersOriginEvent.MESSAGE, { suppressErrors: false })
+  async updateAnswersQuestion(event: UpdateAnswersOriginEvent) {
+    const answer = await this.answerRepository.findById(event.answerId);
+    answer.updateQuestionId(event.questionId);
+    await this.answerRepository.update(answer);
+  }
+
+  async updateAnswersQuestionId(questionId: number, answerId: number) {
+    const event = FindQuestionOriginEvent.of(questionId, answerId);
+    await this.emitter.emitAsync(FindQuestionOriginEvent.MESSAGE, event);
+  }
+
+  async validateQuestionExistence(questionId: number) {
+    const event = ValidateQuestionExistenceEvent.of(questionId);
+    await this.emitter.emitAsync(ValidateQuestionExistenceEvent.MESSAGE, event);
+  }
+
+  async validateQuestionOrigin(questionId: number) {
+    const event = ValidateQuestionOriginEvent.of(questionId);
+    await this.emitter.emitAsync(ValidateQuestionOriginEvent.MESSAGE, event);
+  }
+
+  async updateQuestion(questionId: number, answer: Answer) {
+    const event = UpdateDefaultAnswerEvent.of(questionId, answer);
+    await this.emitter.emitAsync(UpdateDefaultAnswerEvent.MESSAGE, event);
+  }
+
+  async validateOwnershipByQuestionsWorkbook(
+    questionId: number,
+    member: Member,
+  ) {
+    const event = FindQuestionToValidateWorkbookOwnership.of(
+      questionId,
+      member,
+    );
+    await this.emitter.emitAsync(
+      FindQuestionToValidateWorkbookOwnership.MESSAGE,
+      event,
+    );
+  }
+
+  async checkQuestionToBeOrigin(questionId: number) {
+    const event = CheckQuestionToBeOriginEvent.of(questionId);
+    await this.emitter.emitAsync(CheckQuestionToBeOriginEvent.MESSAGE, event);
+  }
+
+  async validateDefaultAnswersExistence(questionId: number) {
+    const event = ValidateDefaultAnswersExistenceEvent.of(questionId);
+    await this.emitter.emitAsync(
+      ValidateDefaultAnswersExistenceEvent.MESSAGE,
+      event,
+    );
+  }
+}

--- a/src/answer/service/answer.service.spec.ts
+++ b/src/answer/service/answer.service.spec.ts
@@ -103,10 +103,6 @@ describe('AnswerService 단위 테스트', () => {
   });
 
   describe('답변 추가', () => {
-    beforeAll(() => {
-      mockEmitter.emitAsync.mockResolvedValue(undefined);
-    });
-
     it('질문에 답변을 추가한다.', async () => {
       //given
       mockQuestionRepository.findOriginById.mockResolvedValue(questionFixture);
@@ -114,6 +110,7 @@ describe('AnswerService 단위 테스트', () => {
       //when
       const answer = Answer.of('test', memberFixture, questionFixture.id);
       mockAnswerRepository.save.mockResolvedValue(answer);
+      mockEmitter.emitAsync.mockResolvedValue(undefined);
 
       //then
       await expect(
@@ -130,9 +127,7 @@ describe('AnswerService 단위 테스트', () => {
       //when
       const answer = Answer.of('test', memberFixture, questionFixture.id);
       mockAnswerRepository.save.mockResolvedValue(answer);
-      mockEmitter.emitAsync.mockRejectedValueOnce(
-        new QuestionNotFoundException(),
-      );
+      mockEmitter.emitAsync.mockRejectedValue(new QuestionNotFoundException());
 
       //then
       await expect(
@@ -199,6 +194,7 @@ describe('AnswerService 단위 테스트', () => {
         ),
       );
       mockAnswerRepository.findById.mockResolvedValue(answerFixture);
+      mockEmitter.emitAsync.mockRejectedValue(new QuestionForbiddenException());
 
       //then
       await expect(
@@ -311,7 +307,7 @@ describe('AnswerService 통합테스트', () => {
   });
 
   describe('대표답변 설정', () => {
-    it('Member와 알맞은 Questin이 온다면, 정상적으로 대표 답변을 설정해준다.', async () => {
+    it('Member와 알맞은 Question이 온다면, 정상적으로 대표 답변을 설정해준다.', async () => {
       //given
       const member = await memberRepository.save(memberFixture);
       await categoryRepository.save(categoryFixtureWithId);

--- a/src/answer/service/answer.service.spec.ts
+++ b/src/answer/service/answer.service.spec.ts
@@ -288,12 +288,12 @@ describe('AnswerService 통합테스트', () => {
       const questionResponse = QuestionResponse.from(updatedQuestion);
 
       //then
-      expect(updatedQuestion.defaultAnswer.id).toEqual(answer.id);
+      expect(updatedQuestion.defaultAnswerId).toEqual(answer.id);
       expect(questionResponse.questionId).toBe(updatedQuestion.id);
       expect(questionResponse.questionContent).toBe(updatedQuestion.content);
-      expect(questionResponse.answerId).toBe(updatedQuestion.defaultAnswer.id);
+      expect(questionResponse.answerId).toBe(updatedQuestion.defaultAnswerId);
       expect(questionResponse.answerContent).toBe(
-        updatedQuestion.defaultAnswer.content,
+        updatedQuestion.defaultAnswerContent,
       );
     });
   });
@@ -411,7 +411,7 @@ describe('AnswerService 통합테스트', () => {
       const afterDeleteQuestion = await questionRepository.findById(
         question.id,
       );
-      expect(afterDeleteQuestion.defaultAnswer).toBeNull();
+      expect(afterDeleteQuestion.defaultAnswerId).toBeNull();
     });
 
     it('답변을 삭제할 때 다른 사람의 답변을 삭제하면 AnswerForbiddenException을 반환한다.', async () => {

--- a/src/answer/service/answer.service.spec.ts
+++ b/src/answer/service/answer.service.spec.ts
@@ -349,13 +349,12 @@ describe('AnswerService 통합테스트', () => {
         Answer.of(`defaultAnswer`, member, question.id),
       );
       question.setDefaultAnswer(answer);
-      await questionRepository.save(question);
+      await questionRepository.update(question);
 
       //when
 
       //then
       const list = await answerService.getAnswerList(question.id);
-      console.log(list);
       expect(list[0].content).toEqual('defaultAnswer');
     });
 
@@ -402,7 +401,7 @@ describe('AnswerService 통합테스트', () => {
         Answer.of(`defaultAnswer`, member, question.id),
       );
       question.setDefaultAnswer(answer);
-      await questionRepository.save(question);
+      await questionRepository.update(question);
 
       //when
 

--- a/src/answer/service/answer.service.spec.ts
+++ b/src/answer/service/answer.service.spec.ts
@@ -112,7 +112,7 @@ describe('AnswerService 단위 테스트', () => {
       mockQuestionRepository.findOriginById.mockResolvedValue(questionFixture);
 
       //when
-      const answer = Answer.of('test', memberFixture, questionFixture);
+      const answer = Answer.of('test', memberFixture, questionFixture.id);
       mockAnswerRepository.save.mockResolvedValue(answer);
 
       //then
@@ -128,7 +128,7 @@ describe('AnswerService 단위 테스트', () => {
       );
 
       //when
-      const answer = Answer.of('test', memberFixture, questionFixture);
+      const answer = Answer.of('test', memberFixture, questionFixture.id);
       mockAnswerRepository.save.mockResolvedValue(answer);
       mockEmitter.emitAsync.mockRejectedValueOnce(
         new QuestionNotFoundException(),
@@ -320,7 +320,7 @@ describe('AnswerService 통합테스트', () => {
         Question.of(workbook.id, null, 'test'),
       );
       const answer = await answerRepository.save(
-        Answer.of('test', member, question),
+        Answer.of('test', member, question.id),
       );
 
       //when
@@ -362,10 +362,10 @@ describe('AnswerService 통합테스트', () => {
       );
       for (let index = 1; index <= 10; index++) {
         await answerRepository.save(
-          Answer.of(`test${index}`, member, question),
+          Answer.of(`test${index}`, member, question.id),
         );
         await answerRepository.save(
-          Answer.of(`TEST${index}`, member1, question),
+          Answer.of(`TEST${index}`, member1, question.id),
         );
       }
 
@@ -386,11 +386,11 @@ describe('AnswerService 통합테스트', () => {
       );
       for (let index = 1; index <= 10; index++) {
         await answerRepository.save(
-          Answer.of(`test${index}`, member, question),
+          Answer.of(`test${index}`, member, question.id),
         );
       }
       const answer = await answerRepository.save(
-        Answer.of(`defaultAnswer`, member, question),
+        Answer.of(`defaultAnswer`, member, question.id),
       );
       question.setDefaultAnswer(answer);
       await questionRepository.save(question);
@@ -414,10 +414,12 @@ describe('AnswerService 통합테스트', () => {
         Question.of(workbook.id, origin, 'test'),
       );
       for (let index = 1; index <= 10; index++) {
-        await answerRepository.save(Answer.of(`test${index}`, member, origin));
+        await answerRepository.save(
+          Answer.of(`test${index}`, member, origin.id),
+        );
       }
       const answer = await answerRepository.save(
-        Answer.of(`defaultAnswer`, member, origin),
+        Answer.of(`defaultAnswer`, member, origin.id),
       );
       question.setDefaultAnswer(answer);
       await questionRepository.save(question);
@@ -440,7 +442,7 @@ describe('AnswerService 통합테스트', () => {
         Question.of(workbook.id, null, 'test'),
       );
       const answer = await answerRepository.save(
-        Answer.of(`defaultAnswer`, member, question),
+        Answer.of(`defaultAnswer`, member, question.id),
       );
       question.setDefaultAnswer(answer);
       await questionRepository.save(question);
@@ -473,7 +475,7 @@ describe('AnswerService 통합테스트', () => {
         Question.of(workbook.id, null, 'test'),
       );
       const answer = await answerRepository.save(
-        Answer.of(`defaultAnswer`, member, question),
+        Answer.of(`defaultAnswer`, member, question.id),
       );
       question.setDefaultAnswer(answer);
       await questionRepository.save(question);
@@ -504,7 +506,7 @@ describe('AnswerService 통합테스트', () => {
         Question.of(workbook.id, null, 'test'),
       );
       const answer = await answerRepository.save(
-        Answer.of(`defaultAnswer`, member, question),
+        Answer.of(`defaultAnswer`, member, question.id),
       );
       question.setDefaultAnswer(answer);
       await questionRepository.save(question);

--- a/src/answer/service/answer.service.spec.ts
+++ b/src/answer/service/answer.service.spec.ts
@@ -395,6 +395,7 @@ describe('AnswerService 통합테스트', () => {
 
       //then
       const list = await answerService.getAnswerList(question.id);
+      console.log(list);
       expect(list[0].content).toEqual('defaultAnswer');
     });
 

--- a/src/answer/service/answer.service.ts
+++ b/src/answer/service/answer.service.ts
@@ -8,7 +8,6 @@ import { Answer } from '../entity/answer';
 import { AnswerResponse } from '../dto/answerResponse';
 import { DefaultAnswerRequest } from '../dto/defaultAnswerRequest';
 import { validateAnswer } from '../util/answer.util';
-import { validateQuestion } from '../../question/util/question.util';
 import { AnswerForbiddenException } from '../exception/answer.exception';
 import { WorkbookRepository } from '../../workbook/repository/workbook.repository';
 import { QuestionForbiddenException } from '../../question/exception/question.exception';
@@ -32,8 +31,7 @@ export class AnswerService {
     const question = await this.questionRepository.findOriginById(
       createAnswerRequest.questionId,
     );
-
-    validateQuestion(question);
+    await this.validateQuestionOrigin(createAnswerRequest.questionId);
 
     const answer = await this.saveAnswerAndQuestion(
       createAnswerRequest,
@@ -51,7 +49,7 @@ export class AnswerService {
     const question = await this.questionRepository.findById(
       defaultAnswerRequest.questionId,
     );
-    validateQuestion(question);
+    await this.validateQuestionExistence(defaultAnswerRequest.questionId);
 
     const workbook = await this.workbookRepository.findById(
       question.workbookId,
@@ -64,9 +62,7 @@ export class AnswerService {
     const answer = await this.answerRepository.findById(
       defaultAnswerRequest.answerId,
     );
-
     validateAnswer(answer);
-
     question.setDefaultAnswer(answer);
     await this.questionRepository.update(question);
   }
@@ -89,7 +85,7 @@ export class AnswerService {
   async getAnswerList(id: number) {
     const question =
       await this.questionRepository.findQuestionWithOriginById(id);
-    validateQuestion(question);
+    await this.validateQuestionExistence(id);
     const questionId = question.origin ? question.origin.id : question.id;
 
     const answers = (

--- a/src/answer/service/answer.service.ts
+++ b/src/answer/service/answer.service.ts
@@ -16,6 +16,7 @@ import { Transactional } from 'typeorm-transactional';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ValidateQuestionExistenceEvent } from 'src/question/event/validate.question.existence.event';
 import { ValidateQuestionOriginEvent } from 'src/question/event/validate.question.origin.event';
+import { UpdateDefaultAnswerEvent } from 'src/question/event/update.default.answer.event';
 
 @Injectable()
 export class AnswerService {
@@ -56,9 +57,7 @@ export class AnswerService {
       defaultAnswerRequest.answerId,
     );
     validateAnswer(answer);
-    // * TODO 질문의 업데이트 로직을 이벤트화
-    // question.setDefaultAnswer(answer);
-    // await this.questionRepository.update(question);
+    await this.updateQuestion(defaultAnswerRequest.questionId, answer);
   }
 
   @Transactional()
@@ -127,5 +126,10 @@ export class AnswerService {
   private async validateQuestionOrigin(questionId: number) {
     const event = ValidateQuestionOriginEvent.of(questionId);
     this.emitter.emitAsync(ValidateQuestionOriginEvent.MESSAGE, event);
+  }
+
+  private async updateQuestion(questionId: number, answer: Answer) {
+    const event = UpdateDefaultAnswerEvent.of(questionId, answer);
+    this.emitter.emitAsync(UpdateDefaultAnswerEvent.MESSAGE, event);
   }
 }

--- a/src/answer/service/answer.service.ts
+++ b/src/answer/service/answer.service.ts
@@ -72,17 +72,6 @@ export class AnswerService {
 
   @Transactional()
   async getAnswerList(questionId: number) {
-    /* 
-    1. question도메인에 검증 이벤트를 발생시킨다.
-    2. 질문의 origin이 있는지 검증한다.
-      2-1. 있을 경우(예외 x)
-          1. 예외에서 questionId를 가져온다. 
-          2. questionId를 통해 질문들을 가져온다. 
-      2-2. 없을 경우(예외 핸들링)
-          1. id로 답변을 조회한다. 
-    3. answer와 question.defaultAnswer을 join해서 question.id가 일치하는 컬럼을 가져온다. 
-    4. 해당 answer를 제일 앞으로 가지는 배열을 반환한다.
-    */
     await this.answerEventHandler.validateQuestionExistence(questionId);
     let originId: number;
     try {

--- a/src/answer/service/answer.service.ts
+++ b/src/answer/service/answer.service.ts
@@ -14,6 +14,8 @@ import { WorkbookRepository } from '../../workbook/repository/workbook.repositor
 import { QuestionForbiddenException } from '../../question/exception/question.exception';
 import { validateWorkbook } from '../../workbook/util/workbook.util';
 import { Transactional } from 'typeorm-transactional';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { ValidateQuestionExistenceEvent } from 'src/question/event/validate.question.existence.event';
 
 @Injectable()
 export class AnswerService {
@@ -21,6 +23,7 @@ export class AnswerService {
     private answerRepository: AnswerRepository,
     private questionRepository: QuestionRepository,
     private workbookRepository: WorkbookRepository,
+    private emitter: EventEmitter2,
   ) {}
 
   @Transactional()
@@ -122,5 +125,10 @@ export class AnswerService {
   ) {
     const answer = Answer.of(createAnswerRequest.content, member, question);
     return await this.answerRepository.save(answer);
+  }
+
+  private async validateQuestionExistence(questionId: number) {
+    const event = ValidateQuestionExistenceEvent.of(questionId);
+    this.emitter.emitAsync(ValidateQuestionExistenceEvent.MESSAGE, event);
   }
 }

--- a/src/answer/service/answer.service.ts
+++ b/src/answer/service/answer.service.ts
@@ -64,6 +64,7 @@ export class AnswerService {
 
     if (answer.isOwnedBy(member)) {
       await this.answerRepository.remove(answer);
+      await this.answerEventHandler.clearDefaultAnswer(answer.id);
       return;
     }
 

--- a/src/answer/service/answer.service.ts
+++ b/src/answer/service/answer.service.ts
@@ -129,22 +129,22 @@ export class AnswerService {
 
   private async updateAnswersQuestionId(questionId: number, answerId: number) {
     const event = FindQuestionOriginEvent.of(questionId, answerId);
-    this.emitter.emitAsync(FindQuestionOriginEvent.MESSAGE, event);
+    await this.emitter.emitAsync(FindQuestionOriginEvent.MESSAGE, event);
   }
 
   private async validateQuestionExistence(questionId: number) {
     const event = ValidateQuestionExistenceEvent.of(questionId);
-    this.emitter.emitAsync(ValidateQuestionExistenceEvent.MESSAGE, event);
+    await this.emitter.emitAsync(ValidateQuestionExistenceEvent.MESSAGE, event);
   }
 
   private async validateQuestionOrigin(questionId: number) {
     const event = ValidateQuestionOriginEvent.of(questionId);
-    this.emitter.emitAsync(ValidateQuestionOriginEvent.MESSAGE, event);
+    await this.emitter.emitAsync(ValidateQuestionOriginEvent.MESSAGE, event);
   }
 
   private async updateQuestion(questionId: number, answer: Answer) {
     const event = UpdateDefaultAnswerEvent.of(questionId, answer);
-    this.emitter.emitAsync(UpdateDefaultAnswerEvent.MESSAGE, event);
+    await this.emitter.emitAsync(UpdateDefaultAnswerEvent.MESSAGE, event);
   }
 
   private async validateOwnershipByQuestionsWorkbook(
@@ -155,7 +155,7 @@ export class AnswerService {
       questionId,
       member,
     );
-    this.emitter.emitAsync(
+    await this.emitter.emitAsync(
       FindQuestionToValidateWorkbookOwnership.MESSAGE,
       event,
     );

--- a/src/answer/service/answer.service.ts
+++ b/src/answer/service/answer.service.ts
@@ -77,20 +77,20 @@ export class AnswerService {
     // 어떻게 수정할까?
     /* TODO
     1. question도메인에 검증 이벤트를 발생시킨다.
-    2. try-catch를 통해 커스텀 예외를 이벤트를 통해 받아와 처리한다?
+    2. 질문의 origin이 있는지 검증한다.
+      2-1. 있을 경우(예외 x)
+          1. 예외에서 questionId를 가져온다. 
+          2. questionId를 통해 질문들을 가져온다. 
+      2-2. 없을 경우(예외 핸들링)
+          1. id로 답변을 조회한다. 
+    3. answer와 question.defaultAnswer을 join해서 question.id가 일치하는 컬럼을 가져온다. 
+    4. 해당 answer를 제일 앞으로 가지는 배열을 반환한다.
     */
-    // const question =
-    //   await this.questionRepository.findQuestionWithOriginById(id);
     await this.validateQuestionExistence(id);
-    // const questionId = question.origin ? question.origin.id : question.id;
 
     const answers = (await this.answerRepository.findAllByQuestionId(id)).map(
       (answer) => AnswerResponse.from(answer, answer.member),
     );
-
-    // if (question.defaultAnswer) {
-    //   return this.createAnswerResponsesWithDefaultAnswer(question, answers);
-    // }
 
     return answers;
   }

--- a/src/answer/service/answer.service.ts
+++ b/src/answer/service/answer.service.ts
@@ -16,6 +16,7 @@ import { validateWorkbook } from '../../workbook/util/workbook.util';
 import { Transactional } from 'typeorm-transactional';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ValidateQuestionExistenceEvent } from 'src/question/event/validate.question.existence.event';
+import { ValidateQuestionOriginEvent } from 'src/question/event/validate.question.origin.event';
 
 @Injectable()
 export class AnswerService {
@@ -130,5 +131,10 @@ export class AnswerService {
   private async validateQuestionExistence(questionId: number) {
     const event = ValidateQuestionExistenceEvent.of(questionId);
     this.emitter.emitAsync(ValidateQuestionExistenceEvent.MESSAGE, event);
+  }
+
+  private async validateQuestionOrigin(questionId: number) {
+    const event = ValidateQuestionOriginEvent.of(questionId);
+    this.emitter.emitAsync(ValidateQuestionOriginEvent.MESSAGE, event);
   }
 }

--- a/src/question/dto/questionResponse.ts
+++ b/src/question/dto/questionResponse.ts
@@ -30,15 +30,14 @@ export class QuestionResponse {
   }
 
   static from(question: Question) {
-    const answer = question.defaultAnswer;
-    if (isEmpty(answer))
+    if (isEmpty(question.defaultAnswerId))
       return new QuestionResponse(question.id, question.content, null, null);
 
     return new QuestionResponse(
       question.id,
       question.content,
-      answer.id,
-      answer.content.toString(),
+      question.defaultAnswerId,
+      question.defaultAnswerContent,
     );
   }
 }

--- a/src/question/entity/question.ts
+++ b/src/question/entity/question.ts
@@ -15,13 +15,11 @@ export class Question extends DefaultEntity {
   @JoinColumn({ name: 'origin' })
   readonly origin: Question;
 
-  @ManyToOne(() => Answer, {
-    nullable: true,
-    onDelete: 'SET NULL',
-    eager: true,
-  })
-  @JoinColumn({ name: 'defaultAnswer' })
-  defaultAnswer: Answer;
+  @Column({ name: 'defaultAnswer', nullable: true })
+  defaultAnswerId: number;
+
+  @Column({ name: 'answerContent', nullable: true })
+  defaultAnswerContent: string;
 
   @Column({ default: 0 })
   indexInWorkbook: number;
@@ -32,18 +30,28 @@ export class Question extends DefaultEntity {
     workbookId: number,
     origin: Question,
     createdAt: Date,
-    defaultAnswer: Answer,
+    defaultAnswerId: number,
+    defaultAnswerContent: string,
   ) {
     super(id, createdAt);
     this.content = content;
     this.workbookId = workbookId;
     this.origin = origin;
-    this.defaultAnswer = defaultAnswer;
+    this.defaultAnswerId = defaultAnswerId;
+    this.defaultAnswerContent = defaultAnswerContent;
     this.indexInWorkbook = 0;
   }
 
   static of(workbookId: number, origin: Question, content: string) {
-    return new Question(null, content, workbookId, origin, new Date(), null);
+    return new Question(
+      null,
+      content,
+      workbookId,
+      origin,
+      new Date(),
+      null,
+      null,
+    );
   }
 
   static copyOf(question: Question, workbookId: number) {
@@ -53,11 +61,13 @@ export class Question extends DefaultEntity {
       workbookId,
       question,
       new Date(),
-      question.defaultAnswer,
+      question.defaultAnswerId,
+      question.defaultAnswerContent,
     );
   }
 
   setDefaultAnswer(answer: Answer) {
-    this.defaultAnswer = answer;
+    this.defaultAnswerId = answer.id;
+    this.defaultAnswerContent = answer.content;
   }
 }

--- a/src/question/entity/question.ts
+++ b/src/question/entity/question.ts
@@ -70,4 +70,9 @@ export class Question extends DefaultEntity {
     this.defaultAnswerId = answer.id;
     this.defaultAnswerContent = answer.content;
   }
+
+  clearDefaultAnswer() {
+    this.defaultAnswerId = null;
+    this.defaultAnswerContent = null;
+  }
 }

--- a/src/question/event/check.question.tobe.origin.event.ts
+++ b/src/question/event/check.question.tobe.origin.event.ts
@@ -1,0 +1,13 @@
+export class CheckQuestionToBeOriginEvent {
+  static readonly MESSAGE = 'question.check.or.throw.origin';
+
+  readonly questionId: number;
+
+  constructor(questionId: number) {
+    this.questionId = questionId;
+  }
+
+  static of(questionId: number) {
+    return new CheckQuestionToBeOriginEvent(questionId);
+  }
+}

--- a/src/question/event/find.question.origin.event.ts
+++ b/src/question/event/find.question.origin.event.ts
@@ -1,0 +1,15 @@
+export class FindQuestionOriginEvent {
+  static readonly MESSAGE = 'question.find.origin';
+
+  readonly questionId: number;
+  readonly answerId: number;
+
+  constructor(questionId: number, answerId: number) {
+    this.questionId = questionId;
+    this.answerId = answerId;
+  }
+
+  static of(questionId: number, answerId: number) {
+    return new FindQuestionOriginEvent(questionId, answerId);
+  }
+}

--- a/src/question/event/find.question.to.validate.workbook.ownership.event.ts
+++ b/src/question/event/find.question.to.validate.workbook.ownership.event.ts
@@ -1,0 +1,17 @@
+import { Member } from 'src/member/entity/member';
+
+export class FindQuestionToValidateWorkbookOwnership {
+  static readonly MESSAGE = 'question.update.defaultAnswer';
+
+  readonly questionId: number;
+  readonly member: Member;
+
+  constructor(questionId: number, member: Member) {
+    this.questionId = questionId;
+    this.member = member;
+  }
+
+  static of(questionId: number, member: Member) {
+    return new FindQuestionToValidateWorkbookOwnership(questionId, member);
+  }
+}

--- a/src/question/event/find.question.to.validate.workbook.ownership.event.ts
+++ b/src/question/event/find.question.to.validate.workbook.ownership.event.ts
@@ -1,7 +1,7 @@
 import { Member } from 'src/member/entity/member';
 
 export class FindQuestionToValidateWorkbookOwnership {
-  static readonly MESSAGE = 'question.update.defaultAnswer';
+  static readonly MESSAGE = 'question.find.to.validate.workbook.ownership';
 
   readonly questionId: number;
   readonly member: Member;

--- a/src/question/event/update.default.answer.event.ts
+++ b/src/question/event/update.default.answer.event.ts
@@ -1,0 +1,17 @@
+import { Answer } from 'src/answer/entity/answer';
+
+export class UpdateDefaultAnswerEvent {
+  static readonly MESSAGE = 'question.update.defaultAnswer';
+
+  readonly questionId: number;
+  readonly defaultAnswer: Answer;
+
+  constructor(questionId: number, answer: Answer) {
+    this.questionId = questionId;
+    this.defaultAnswer = answer;
+  }
+
+  static of(questionId: number, answer: Answer) {
+    return new UpdateDefaultAnswerEvent(questionId, answer);
+  }
+}

--- a/src/question/event/validate.default.answers.existence.event.ts
+++ b/src/question/event/validate.default.answers.existence.event.ts
@@ -1,0 +1,13 @@
+export class ValidateDefaultAnswersExistenceEvent {
+  static readonly MESSAGE = 'question.validate.default.answer.existence';
+
+  readonly questionId: number;
+
+  constructor(questionId: number) {
+    this.questionId = questionId;
+  }
+
+  static of(questionId: number) {
+    return new ValidateDefaultAnswersExistenceEvent(questionId);
+  }
+}

--- a/src/question/event/validate.question.existence.event.ts
+++ b/src/question/event/validate.question.existence.event.ts
@@ -1,0 +1,13 @@
+export class ValidateQuestionExistenceEvent {
+  static readonly MESSAGE = 'question.validate.existence';
+
+  readonly questionId: number;
+
+  constructor(questionId: number) {
+    this.questionId = questionId;
+  }
+
+  static of(questionId: number) {
+    return new ValidateQuestionExistenceEvent(questionId);
+  }
+}

--- a/src/question/event/validate.question.origin.event.ts
+++ b/src/question/event/validate.question.origin.event.ts
@@ -1,0 +1,13 @@
+export class ValidateQuestionOriginEvent {
+  static readonly MESSAGE = 'question.validate.origin';
+
+  readonly questionId: number;
+
+  constructor(questionId: number) {
+    this.questionId = questionId;
+  }
+
+  static of(questionId: number) {
+    return new ValidateQuestionOriginEvent(questionId);
+  }
+}

--- a/src/question/exception/question.exception.ts
+++ b/src/question/exception/question.exception.ts
@@ -25,4 +25,27 @@ class QuestionForbiddenException extends HttpForbiddenException {
   }
 }
 
-export { QuestionNotFoundException, QuestionForbiddenException };
+class QuestionOriginFound extends Error {
+  readonly originId: number;
+
+  constructor(originId: number) {
+    super();
+    this.originId = originId;
+  }
+}
+
+class QuestionDefaultAnswerExists extends Error {
+  readonly answerId: number;
+
+  constructor(answerId: number) {
+    super();
+    this.answerId = answerId;
+  }
+}
+
+export {
+  QuestionNotFoundException,
+  QuestionForbiddenException,
+  QuestionOriginFound,
+  QuestionDefaultAnswerExists,
+};

--- a/src/question/fixture/question.fixture.ts
+++ b/src/question/fixture/question.fixture.ts
@@ -11,13 +11,46 @@ export const questionFixture = new Question(
   null,
   new Date(),
   null,
+  null,
 );
 
 export const questionListFixture = [
-  new Question(1, 'tester', workbookFixtureWithId.id, null, new Date(), null),
-  new Question(2, 'tester', workbookFixtureWithId.id, null, new Date(), null),
-  new Question(3, 'tester', workbookFixtureWithId.id, null, new Date(), null),
-  new Question(4, 'tester', workbookFixtureWithId.id, null, new Date(), null),
+  new Question(
+    1,
+    'tester',
+    workbookFixtureWithId.id,
+    null,
+    new Date(),
+    null,
+    null,
+  ),
+  new Question(
+    2,
+    'tester',
+    workbookFixtureWithId.id,
+    null,
+    new Date(),
+    null,
+    null,
+  ),
+  new Question(
+    3,
+    'tester',
+    workbookFixtureWithId.id,
+    null,
+    new Date(),
+    null,
+    null,
+  ),
+  new Question(
+    4,
+    'tester',
+    workbookFixtureWithId.id,
+    null,
+    new Date(),
+    null,
+    null,
+  ),
 ];
 
 export const createQuestionRequestFixture = new CreateQuestionRequest(

--- a/src/question/question.module.ts
+++ b/src/question/question.module.ts
@@ -7,10 +7,11 @@ import { QuestionController } from './controller/question.controller';
 import { QuestionRepository } from './repository/question.repository';
 import { Member } from '../member/entity/member';
 import { Answer } from '../answer/entity/answer';
+import { QuestionEventHandler } from './service/question.event.handler';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Question, Member, Answer]), TokenModule],
-  providers: [QuestionService, QuestionRepository],
+  providers: [QuestionService, QuestionRepository, QuestionEventHandler],
   controllers: [QuestionController],
 })
 export class QuestionModule {}

--- a/src/question/repository/question.repository.ts
+++ b/src/question/repository/question.repository.ts
@@ -30,7 +30,6 @@ export class QuestionRepository {
     return await this.repository
       .createQueryBuilder('Question')
       .leftJoinAndSelect('Question.origin', 'origin')
-      .leftJoinAndSelect('Question.defaultAnswer', 'defaultAnswer')
       .where('Question.workbook = :workbookId', { workbookId })
       .orderBy('Question.indexInWorkbook', 'ASC')
       .getMany();
@@ -40,7 +39,6 @@ export class QuestionRepository {
     return await this.repository
       .createQueryBuilder('Question')
       .leftJoinAndSelect('Question.origin', 'origin')
-      .leftJoinAndSelect('Question.defaultAnswer', 'defaultAnswer')
       .where('Question.id IN (:...ids)', { ids })
       .getMany();
   }
@@ -53,7 +51,6 @@ export class QuestionRepository {
     return await this.repository
       .createQueryBuilder('Question')
       .leftJoinAndSelect('Question.origin', 'origin')
-      .leftJoinAndSelect('Question.defaultAnswer', 'defaultAnswer')
       .where('Question.id = :id', { id })
       .getOne();
   }

--- a/src/question/repository/question.repository.ts
+++ b/src/question/repository/question.repository.ts
@@ -55,6 +55,10 @@ export class QuestionRepository {
       .getOne();
   }
 
+  async findAllByDefaultAnswerId(answerId: number) {
+    return await this.repository.findBy({ defaultAnswerId: answerId });
+  }
+
   async findOriginById(id: number): Promise<Question | null> {
     const question = await this.findQuestionWithOriginById(id);
     return this.fetchOrigin(question);
@@ -62,6 +66,18 @@ export class QuestionRepository {
 
   async update(question: Question) {
     await this.repository.update({ id: question.id }, question);
+  }
+
+  async clearDefaultAnswer(questions: Question[]) {
+    await this.repository
+      .createQueryBuilder()
+      .update(Question)
+      .set({
+        defaultAnswerId: null,
+        defaultAnswerContent: null,
+      })
+      .whereInIds(questions.map((each) => each.id))
+      .execute();
   }
 
   async remove(question: Question) {

--- a/src/question/service/question.event.handler.ts
+++ b/src/question/service/question.event.handler.ts
@@ -92,8 +92,8 @@ export class QuestionEventHandler {
     const question = await this.questionRepository.findQuestionWithOriginById(
       event.questionId,
     );
-    if (question.defaultAnswer) {
-      throw new QuestionDefaultAnswerExists(question.defaultAnswer.id);
+    if (question.defaultAnswerId) {
+      throw new QuestionDefaultAnswerExists(question.defaultAnswerId);
     }
   }
 

--- a/src/question/service/question.event.handler.ts
+++ b/src/question/service/question.event.handler.ts
@@ -17,6 +17,7 @@ import {
 import { ValidateDefaultAnswersExistenceEvent } from '../event/validate.default.answers.existence.event';
 import { Member } from 'src/member/entity/member';
 import { IncreaseCopyCountEvent } from 'src/workbook/event/increase.copyCount.event';
+import { ClearDefaultAnswerEvent } from 'src/answer/event/clear.default.answer.event';
 
 @Injectable()
 export class QuestionEventHandler {
@@ -95,6 +96,14 @@ export class QuestionEventHandler {
     if (question.defaultAnswerId) {
       throw new QuestionDefaultAnswerExists(question.defaultAnswerId);
     }
+  }
+
+  @OnEvent(ClearDefaultAnswerEvent.MESSAGE, { suppressErrors: false })
+  async clearDefaultAnswer(event: ClearDefaultAnswerEvent) {
+    const questions = await this.questionRepository.findAllByDefaultAnswerId(
+      event.answerId,
+    );
+    await this.questionRepository.clearDefaultAnswer(questions);
   }
 
   async validateWorkbookOwnership(workbookId: number, member: Member) {

--- a/src/question/service/question.event.handler.ts
+++ b/src/question/service/question.event.handler.ts
@@ -1,0 +1,111 @@
+import { Injectable } from '@nestjs/common';
+import { QuestionRepository } from '../repository/question.repository';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import { ValidateQuestionExistenceEvent } from '../event/validate.question.existence.event';
+import { validateQuestion } from '../util/question.util';
+import { ValidateQuestionOriginEvent } from '../event/validate.question.origin.event';
+import { UpdateDefaultAnswerEvent } from '../event/update.default.answer.event';
+import { FindQuestionToValidateWorkbookOwnership } from '../event/find.question.to.validate.workbook.ownership.event';
+import { ValidateWorkbookEvent } from 'src/workbook/event/validate.workbook.event';
+import { FindQuestionOriginEvent } from '../event/find.question.origin.event';
+import { UpdateAnswersOriginEvent } from 'src/answer/event/update.answer.origin.event';
+import { CheckQuestionToBeOriginEvent } from '../event/check.question.tobe.origin.event';
+import {
+  QuestionDefaultAnswerExists,
+  QuestionOriginFound,
+} from '../exception/question.exception';
+import { ValidateDefaultAnswersExistenceEvent } from '../event/validate.default.answers.existence.event';
+import { Member } from 'src/member/entity/member';
+import { IncreaseCopyCountEvent } from 'src/workbook/event/increase.copyCount.event';
+
+@Injectable()
+export class QuestionEventHandler {
+  constructor(
+    private questionRepository: QuestionRepository,
+    private emitter: EventEmitter2,
+  ) {}
+
+  @OnEvent(ValidateQuestionExistenceEvent.MESSAGE, { suppressErrors: false })
+  async validateQuestionExistence(event: ValidateQuestionExistenceEvent) {
+    const question = await this.questionRepository.findById(event.questionId);
+    validateQuestion(question);
+  }
+
+  @OnEvent(ValidateQuestionOriginEvent.MESSAGE, { suppressErrors: false })
+  async validateQuestionOrigin(event: ValidateQuestionOriginEvent) {
+    const question = await this.questionRepository.findOriginById(
+      event.questionId,
+    );
+    validateQuestion(question);
+  }
+
+  @OnEvent(UpdateDefaultAnswerEvent.MESSAGE, { suppressErrors: false })
+  async updateDefaultAnswer(event: UpdateDefaultAnswerEvent) {
+    const question = await this.questionRepository.findById(event.questionId);
+    validateQuestion(question);
+    question.setDefaultAnswer(event.defaultAnswer);
+    await this.questionRepository.update(question);
+  }
+
+  @OnEvent(FindQuestionToValidateWorkbookOwnership.MESSAGE, {
+    suppressErrors: false,
+  })
+  async validateWorkbookOwnershipByWorkbookId(
+    event: FindQuestionToValidateWorkbookOwnership,
+  ) {
+    const question = await this.questionRepository.findById(event.questionId);
+    const workbookEvent = ValidateWorkbookEvent.of(
+      event.member,
+      question.workbookId,
+    );
+    await this.emitter.emitAsync(ValidateWorkbookEvent.MESSAGE, workbookEvent);
+  }
+
+  @OnEvent(FindQuestionOriginEvent.MESSAGE, { suppressErrors: false })
+  async findQuestionsOriginToUpdateAnswer(event: FindQuestionOriginEvent) {
+    const question = await this.questionRepository.findOriginById(
+      event.questionId,
+    );
+    const updateEvent = UpdateAnswersOriginEvent.of(
+      question.id,
+      event.answerId,
+    );
+    await this.emitter.emitAsync(UpdateAnswersOriginEvent.MESSAGE, updateEvent);
+  }
+
+  @OnEvent(CheckQuestionToBeOriginEvent.MESSAGE, { suppressErrors: false })
+  async checkQuestionToBeOrigin(event: CheckQuestionToBeOriginEvent) {
+    const question = await this.questionRepository.findOriginById(
+      event.questionId,
+    );
+    if (question.id !== event.questionId) {
+      throw new QuestionOriginFound(question.id);
+    }
+  }
+
+  @OnEvent(ValidateDefaultAnswersExistenceEvent.MESSAGE, {
+    suppressErrors: false,
+  })
+  async validateDefaultAnswersExistence(
+    event: ValidateDefaultAnswersExistenceEvent,
+  ) {
+    const question = await this.questionRepository.findQuestionWithOriginById(
+      event.questionId,
+    );
+    if (question.defaultAnswer) {
+      throw new QuestionDefaultAnswerExists(question.defaultAnswer.id);
+    }
+  }
+
+  async validateWorkbookOwnership(workbookId: number, member: Member) {
+    await this.emitter.emitAsync(
+      ValidateWorkbookEvent.MESSAGE,
+      ValidateWorkbookEvent.of(member, workbookId),
+    );
+  }
+
+  async increaseWorkbookCopyCount(workbookId: number) {
+    const event = IncreaseCopyCountEvent.of(workbookId);
+    await this.emitter.emitAsync(IncreaseCopyCountEvent.MESSAGE, event);
+  }
+}

--- a/src/question/service/question.service.spec.ts
+++ b/src/question/service/question.service.spec.ts
@@ -44,6 +44,7 @@ import { WorkbookIdResponse } from '../../workbook/dto/workbookIdResponse';
 import { CopyQuestionRequest } from '../dto/copyQuestionRequest';
 import { UpdateIndexInWorkbookRequest } from '../dto/updateIndexInWorkbookRequest';
 import { EventEmitter2, EventEmitterModule } from '@nestjs/event-emitter';
+import { QuestionEventHandler } from './question.event.handler';
 
 describe('QuestionService', () => {
   let service: QuestionService;
@@ -73,7 +74,12 @@ describe('QuestionService', () => {
         await createTypeOrmModuleForTest(),
         EventEmitterModule.forRoot(),
       ],
-      providers: [QuestionService, QuestionRepository, EventEmitter2],
+      providers: [
+        QuestionService,
+        QuestionRepository,
+        EventEmitter2,
+        QuestionEventHandler,
+      ],
     })
       .overrideProvider(QuestionRepository)
       .useValue(mockQuestionRepository)

--- a/src/question/service/question.service.ts
+++ b/src/question/service/question.service.ts
@@ -20,6 +20,8 @@ import { ValidateQuestionExistenceEvent } from '../event/validate.question.exist
 import { ValidateQuestionOriginEvent } from '../event/validate.question.origin.event';
 import { UpdateDefaultAnswerEvent } from '../event/update.default.answer.event';
 import { FindQuestionToValidateWorkbookOwnership } from '../event/find.question.to.validate.workbook.ownership.event';
+import { FindQuestionOriginEvent } from '../event/find.question.origin.event';
+import { UpdateAnswersOriginEvent } from 'src/answer/event/update.answer.origin.event';
 
 @Injectable()
 export class QuestionService {
@@ -147,6 +149,18 @@ export class QuestionService {
       question.workbookId,
     );
     await this.emitter.emitAsync(ValidateWorkbookEvent.MESSAGE, workbookEvent);
+  }
+
+  @OnEvent(FindQuestionOriginEvent.MESSAGE, { suppressErrors: false })
+  async findQuestionsOriginToUpdateAnswer(event: FindQuestionOriginEvent) {
+    const question = await this.questionRepository.findOriginById(
+      event.questionId,
+    );
+    const updateEvent = UpdateAnswersOriginEvent.of(
+      question.id,
+      event.answerId,
+    );
+    await this.emitter.emitAsync(UpdateAnswersOriginEvent.MESSAGE, updateEvent);
   }
 
   private validateQuestionsByIds(questions: Question[], ids: number[]) {

--- a/src/question/service/question.service.ts
+++ b/src/question/service/question.service.ts
@@ -18,6 +18,7 @@ import { ValidateWorkbookEvent } from 'src/workbook/event/validate.workbook.even
 import { IncreaseCopyCountEvent } from 'src/workbook/event/increase.copyCount.event';
 import { ValidateQuestionExistenceEvent } from '../event/validate.question.existence.event';
 import { ValidateQuestionOriginEvent } from '../event/validate.question.origin.event';
+import { UpdateDefaultAnswerEvent } from '../event/update.default.answer.event';
 
 @Injectable()
 export class QuestionService {
@@ -123,6 +124,14 @@ export class QuestionService {
       event.questionId,
     );
     validateQuestion(question);
+  }
+
+  @OnEvent(UpdateDefaultAnswerEvent.MESSAGE, { suppressErrors: false })
+  async updateDefaultAnswer(event: UpdateDefaultAnswerEvent) {
+    const question = await this.questionRepository.findById(event.questionId);
+    validateQuestion(question);
+    question.setDefaultAnswer(event.defaultAnswer);
+    await this.questionRepository.update(question);
   }
 
   private validateQuestionsByIds(questions: Question[], ids: number[]) {

--- a/src/question/service/question.service.ts
+++ b/src/question/service/question.service.ts
@@ -19,6 +19,7 @@ import { IncreaseCopyCountEvent } from 'src/workbook/event/increase.copyCount.ev
 import { ValidateQuestionExistenceEvent } from '../event/validate.question.existence.event';
 import { ValidateQuestionOriginEvent } from '../event/validate.question.origin.event';
 import { UpdateDefaultAnswerEvent } from '../event/update.default.answer.event';
+import { FindQuestionToValidateWorkbookOwnership } from '../event/find.question.to.validate.workbook.ownership.event';
 
 @Injectable()
 export class QuestionService {
@@ -132,6 +133,20 @@ export class QuestionService {
     validateQuestion(question);
     question.setDefaultAnswer(event.defaultAnswer);
     await this.questionRepository.update(question);
+  }
+
+  @OnEvent(FindQuestionToValidateWorkbookOwnership.MESSAGE, {
+    suppressErrors: false,
+  })
+  async validateWorkbookOwnershipByWorkbookId(
+    event: FindQuestionToValidateWorkbookOwnership,
+  ) {
+    const question = await this.questionRepository.findById(event.questionId);
+    const workbookEvent = ValidateWorkbookEvent.of(
+      event.member,
+      question.workbookId,
+    );
+    await this.emitter.emitAsync(ValidateWorkbookEvent.MESSAGE, workbookEvent);
   }
 
   private validateQuestionsByIds(questions: Question[], ids: number[]) {

--- a/src/question/service/question.service.ts
+++ b/src/question/service/question.service.ts
@@ -13,9 +13,10 @@ import { NeedToFindByWorkbookIdException } from '../../workbook/exception/workbo
 import { Transactional } from 'typeorm-transactional';
 import { UpdateIndexInWorkbookRequest } from '../dto/updateIndexInWorkbookRequest';
 import { QuestionNotFoundException } from '../exception/question.exception';
-import { EventEmitter2 } from '@nestjs/event-emitter';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import { ValidateWorkbookEvent } from 'src/workbook/event/validate.workbook.event';
 import { IncreaseCopyCountEvent } from 'src/workbook/event/increase.copyCount.event';
+import { ValidateQuestionExistenceEvent } from '../event/validate.question.existence.event';
 
 @Injectable()
 export class QuestionService {
@@ -107,6 +108,12 @@ export class QuestionService {
 
     this.validateQuestionsByIds(questions, updateIndexRequest.ids);
     await this.questionRepository.updateIndex(updateIndexRequest.ids);
+  }
+
+  @OnEvent(ValidateQuestionExistenceEvent.MESSAGE, { suppressErrors: false })
+  async validateQuestionExistence(event: ValidateQuestionExistenceEvent) {
+    const question = await this.questionRepository.findById(event.questionId);
+    validateQuestion(question);
   }
 
   private validateQuestionsByIds(questions: Question[], ids: number[]) {

--- a/src/question/service/question.service.ts
+++ b/src/question/service/question.service.ts
@@ -17,6 +17,7 @@ import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import { ValidateWorkbookEvent } from 'src/workbook/event/validate.workbook.event';
 import { IncreaseCopyCountEvent } from 'src/workbook/event/increase.copyCount.event';
 import { ValidateQuestionExistenceEvent } from '../event/validate.question.existence.event';
+import { ValidateQuestionOriginEvent } from '../event/validate.question.origin.event';
 
 @Injectable()
 export class QuestionService {
@@ -113,6 +114,14 @@ export class QuestionService {
   @OnEvent(ValidateQuestionExistenceEvent.MESSAGE, { suppressErrors: false })
   async validateQuestionExistence(event: ValidateQuestionExistenceEvent) {
     const question = await this.questionRepository.findById(event.questionId);
+    validateQuestion(question);
+  }
+
+  @OnEvent(ValidateQuestionOriginEvent.MESSAGE, { suppressErrors: false })
+  async validateQuestionOrigin(event: ValidateQuestionOriginEvent) {
+    const question = await this.questionRepository.findOriginById(
+      event.questionId,
+    );
     validateQuestion(question);
   }
 

--- a/src/workbook/event/validate.workbook.ownership.event.ts
+++ b/src/workbook/event/validate.workbook.ownership.event.ts
@@ -1,7 +1,7 @@
 import { Member } from 'src/member/entity/member';
 
-export class ValidateWorkbookOwnershipEvent {
-  static readonly MESSAGE = 'question.update.defaultAnswer';
+export class ValidateWorkbookOwnershipForQuestionEvent {
+  static readonly MESSAGE = 'workbook.validate.ownership.to.question';
 
   readonly workbookId: number;
   readonly member: Member;
@@ -12,6 +12,6 @@ export class ValidateWorkbookOwnershipEvent {
   }
 
   static of(workbookId: number, member: Member) {
-    return new ValidateWorkbookOwnershipEvent(workbookId, member);
+    return new ValidateWorkbookOwnershipForQuestionEvent(workbookId, member);
   }
 }

--- a/src/workbook/event/validate.workbook.ownership.event.ts
+++ b/src/workbook/event/validate.workbook.ownership.event.ts
@@ -1,0 +1,17 @@
+import { Member } from 'src/member/entity/member';
+
+export class ValidateWorkbookOwnershipEvent {
+  static readonly MESSAGE = 'question.update.defaultAnswer';
+
+  readonly workbookId: number;
+  readonly member: Member;
+
+  constructor(workbookId: number, member: Member) {
+    this.workbookId = workbookId;
+    this.member = member;
+  }
+
+  static of(workbookId: number, member: Member) {
+    return new ValidateWorkbookOwnershipEvent(workbookId, member);
+  }
+}

--- a/src/workbook/service/workbook.event.handler.ts
+++ b/src/workbook/service/workbook.event.handler.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { WorkbookRepository } from '../repository/workbook.repository';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
+import { ValidateWorkbookEvent } from '../event/validate.workbook.event';
+import {
+  WorkbookForbiddenException,
+  WorkbookNotFoundException,
+} from '../exception/workbook.exception';
+import { ValidateWorkbookOwnershipForQuestionEvent } from '../event/validate.workbook.ownership.event';
+import { isEmpty } from 'class-validator';
+import { QuestionForbiddenException } from 'src/question/exception/question.exception';
+import { IncreaseCopyCountEvent } from '../event/increase.copyCount.event';
+
+@Injectable()
+export class WorkbookEventHandler {
+  constructor(
+    private workbookRepository: WorkbookRepository,
+    private emitter: EventEmitter2,
+  ) {}
+
+  @OnEvent(ValidateWorkbookEvent.MESSAGE, {
+    suppressErrors: false,
+  })
+  async validateWorkbookOwner(validateWorkbookEvent: ValidateWorkbookEvent) {
+    const member = validateWorkbookEvent.member;
+    const workbook = await this.workbookRepository.findById(
+      validateWorkbookEvent.workbookId,
+    );
+    if (isEmpty(workbook)) throw new WorkbookNotFoundException();
+    if (!workbook.isOwnedBy(member)) throw new WorkbookForbiddenException();
+  }
+
+  @OnEvent(ValidateWorkbookOwnershipForQuestionEvent.MESSAGE, {
+    suppressErrors: false,
+  })
+  async validateWorkbookOwnershipForQuestion(
+    event: ValidateWorkbookOwnershipForQuestionEvent,
+  ) {
+    const member = event.member;
+    const workbook = await this.workbookRepository.findById(event.workbookId);
+    if (isEmpty(workbook)) throw new WorkbookNotFoundException();
+    if (!workbook.isOwnedBy(member)) throw new QuestionForbiddenException();
+  }
+
+  @OnEvent(IncreaseCopyCountEvent.MESSAGE, { suppressErrors: false })
+  async increaseCopyCount(event: IncreaseCopyCountEvent) {
+    const workbook = await this.workbookRepository.findById(event.workbookId);
+
+    if (isEmpty(workbook)) throw new WorkbookNotFoundException();
+    workbook.increaseCopyCount();
+    await this.workbookRepository.update(workbook);
+  }
+
+  async validateCategoryExistence(categoryId: number) {
+    await this.emitter.emitAsync('category.validate', categoryId);
+  }
+}

--- a/src/workbook/service/workbook.service.spec.ts
+++ b/src/workbook/service/workbook.service.spec.ts
@@ -41,6 +41,7 @@ import { WorkbookTitleResponse } from '../dto/workbookTitleResponse';
 import { UpdateWorkbookRequest } from '../dto/updateWorkbookRequest';
 import { TokenModule } from '../../token/token.module';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { WorkbookEventHandler } from './workbook.event.handler';
 
 describe('WorkbookService 단위테스트', () => {
   let module: TestingModule;
@@ -70,7 +71,12 @@ describe('WorkbookService 단위테스트', () => {
   beforeAll(async () => {
     module = await Test.createTestingModule({
       imports: [await createTypeOrmModuleForTest()],
-      providers: [WorkbookService, WorkbookRepository, EventEmitter2],
+      providers: [
+        WorkbookService,
+        WorkbookRepository,
+        EventEmitter2,
+        WorkbookEventHandler,
+      ],
     })
       .overrideProvider(WorkbookRepository)
       .useValue(mockWorkbookRepository)
@@ -112,10 +118,6 @@ describe('WorkbookService 단위테스트', () => {
       await expect(
         service.createWorkbook(createWorkbookRequestFixture, memberFixture),
       ).rejects.toThrow(new CategoryNotFoundException());
-      expect(service.emitter.emitAsync).toHaveBeenCalledWith(
-        'category.validate',
-        100,
-      );
     });
 
     it('문제집을 추가할 때, Member가 비어있다면 Manipulated예외를 반환시킨다.', async () => {

--- a/src/workbook/service/workbook.service.ts
+++ b/src/workbook/service/workbook.service.ts
@@ -17,7 +17,7 @@ import {
   WorkbookNotFoundException,
 } from '../exception/workbook.exception';
 import { IncreaseCopyCountEvent } from '../event/increase.copyCount.event';
-import { ValidateWorkbookOwnershipEvent } from '../event/validate.workbook.ownership.event';
+import { ValidateWorkbookOwnershipForQuestionEvent } from '../event/validate.workbook.ownership.event';
 import { QuestionForbiddenException } from 'src/question/exception/question.exception';
 
 @Injectable()
@@ -126,11 +126,11 @@ export class WorkbookService {
     if (!workbook.isOwnedBy(member)) throw new WorkbookForbiddenException();
   }
 
-  @OnEvent(ValidateWorkbookOwnershipEvent.MESSAGE, {
+  @OnEvent(ValidateWorkbookOwnershipForQuestionEvent.MESSAGE, {
     suppressErrors: false,
   })
   async validateWorkbookOwnershipForQuestion(
-    event: ValidateWorkbookOwnershipEvent,
+    event: ValidateWorkbookOwnershipForQuestionEvent,
   ) {
     const member = event.member;
     const workbook = await this.workbookRepository.findById(event.workbookId);

--- a/src/workbook/service/workbook.service.ts
+++ b/src/workbook/service/workbook.service.ts
@@ -17,6 +17,8 @@ import {
   WorkbookNotFoundException,
 } from '../exception/workbook.exception';
 import { IncreaseCopyCountEvent } from '../event/increase.copyCount.event';
+import { ValidateWorkbookOwnershipEvent } from '../event/validate.workbook.ownership.event';
+import { QuestionForbiddenException } from 'src/question/exception/question.exception';
 
 @Injectable()
 export class WorkbookService {
@@ -122,6 +124,18 @@ export class WorkbookService {
     );
     if (isEmpty(workbook)) throw new WorkbookNotFoundException();
     if (!workbook.isOwnedBy(member)) throw new WorkbookForbiddenException();
+  }
+
+  @OnEvent(ValidateWorkbookOwnershipEvent.MESSAGE, {
+    suppressErrors: false,
+  })
+  async validateWorkbookOwnershipForQuestion(
+    event: ValidateWorkbookOwnershipEvent,
+  ) {
+    const member = event.member;
+    const workbook = await this.workbookRepository.findById(event.workbookId);
+    if (isEmpty(workbook)) throw new WorkbookNotFoundException();
+    if (!workbook.isOwnedBy(member)) throw new QuestionForbiddenException();
   }
 
   @OnEvent(IncreaseCopyCountEvent.MESSAGE, { suppressErrors: false })

--- a/src/workbook/workbook.module.ts
+++ b/src/workbook/workbook.module.ts
@@ -6,10 +6,16 @@ import { WorkbookService } from './service/workbook.service';
 import { WorkbookController } from './controller/workbook.controller';
 import { TokenSoftGuard } from '../token/guard/token.soft.guard';
 import { TokenModule } from '../token/token.module';
+import { WorkbookEventHandler } from './service/workbook.event.handler';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Workbook]), TokenModule],
-  providers: [WorkbookRepository, WorkbookService, TokenSoftGuard],
+  providers: [
+    WorkbookRepository,
+    WorkbookService,
+    TokenSoftGuard,
+    WorkbookEventHandler,
+  ],
   controllers: [WorkbookController],
 })
 export class WorkbookModule {}


### PR DESCRIPTION
# Why

- Answer 도메인의 분리
    - Question의 DefaultAnswer를 분리했다. 
    - Answer도메인에서 사용하던 Question관련 로직을 분리했다. 
    - EventHandler를 만들어, 비즈니스로직과 이벤트 로직을 분리했다. 

# How

- 이전의 플로우에서 Answer, Question도메인의 깊은 결합을 자주 활용했었다. 
- 해당 부분을 리펙토링하면서, 분리해야할 필요성을 느꼈다. 
    - 각 리포지토리가, 다른 리포지토리를 위한 로직을 빈번하게 사용했었다. 
    - 자기 도메인만을 위한 일을 해야한다. 
        - ex) 질문 도메인의 리포지토리가 대표답변을 쿼리에서 긁어와 조회하는 일이 빈번했다. 

- 해결 방안
    - 역정규화를 이용했다. 
    - Question도메인이 DefaultAnswer(Answer도메인)을 간접참조할 경우, 다른 도메인에 대한 잦은 요청을 보내게 된다. 
    - 이를 위해, Question 도메인에서 자주 사용하는 DefaultAnswer부분을 수정했다.

![스크린샷 2024-02-26 16 17 05](https://github.com/the-NDD/Gomterview-BE/assets/99702271/cc076ff8-39b7-4e94-95ff-8a10d29d37df)

- 이러한 방식으로, 다른 테이블을 조회하는 잦은 동작을 줄일 수 있다. 
- 역정규화의 장점은?
    - 속도가 빠르다. 
    - 도메인간의 독립성을 향상시킬 수 있다. 
- 역정규화의 단점은?
    - 데이터의 중복이 존재한다. 
        - 특히 이 부분은, 역정규화된 다른 엔티티가 삭제될 때, 우리는 이를 직접 처리해야 한다는 단점이 존재했다. 
        - 그래서, 답변 삭제 로직에서 대표답변으로 존재하는 질문들을 다 가져와 벌크로 update해주는 쿼리를 보내주어야 했다. 

# Result

- Answer도메인의 분리
    - Question의 DefaultAnswer분리
    - Answer도메인의 Question도메인 직접참조를 간접참조로 수정

# Prize

- 이벤트를 이용한 다른 도메인간의 협업을 하게 했다. 
- 이벤트를 통한 특정한 데이터가 필요한 경우가 존재했다. 
    - 이를 Exception핸들러를 이용해 구현해두었다. 
    - 더 나은 방법을 찾아야 할 필요가 있을 것 같다. 
- DB의 데이터 수정이 필요하다. 
    - Answer Domain -> DefaultAnswerId, DefaultAnswerContent로 수정하면서 데이터를 참조하지 않아, Content가 null로 갈 수 있다. 
    - 해당 부분을 후에 데이터그립등을 이용해 마이그레이션해주어야 할 필요가 있다. 

# Reference

<!-- 해당 테스크를 수행하며 참고한 Link를 모두 작성합니다. -->

# Link

<!-- jira 혹은 figma 링크를 작성합니다. (Jira ISSUE 번호) -->