### PR TITLE
[NDD-424] EC2 마이그레이션을 위한 cd 스크립트에서의 컨테이너 이름 변경

### DIFF
--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Delete Old docker container
         run: sudo docker rm -f server || true
       - name: Run Docker Container
-        run: docker run --memory=1g --memory-swap=2g --restart=unless-stopped -d -p 80:8080 --name server --network ndd-network ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}}
+        run: docker run --memory=1g --memory-swap=2g --restart=unless-stopped -d -p 80:8080 --name dev-server --network ndd-network ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}}

--- a/.github/workflows/be-cd-dev.yml
+++ b/.github/workflows/be-cd-dev.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Delete Old docker container
         run: sudo docker rm -f server || true
       - name: Run Docker Container
-        run: docker run --memory=1g --memory-swap=2g --restart=unless-stopped -d -p 80:8080 --name dev-server --network ndd-network ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}}
+        run: docker run --memory=1g --memory-swap=2g --restart=unless-stopped -d -p 80:8081 --name dev-server --network ndd-network ${{secrets.BE_DOCKER_USERNAME}}/${{secrets.BE_DOCKER_REPO}}:${{secrets.DOCKER_DEV_TAG}}


### PR DESCRIPTION
[![NDD-424](https://badgen.net/badge/JIRA/NDD-424/blue?icon=jira)](https://milk717.atlassian.net/browse/NDD-424) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=the-NDD&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# Why
EC2 비용을 줄이기 위해 컨테이너를 하나의 EC2에서 돌리기 위해서 dev용 컨테이너의 이름을 변경

# How
dev 컨테이너의 이름을 server에서 dev-server로 변경

# Result
dev 서버에 사용할 컨테이너의 이름을 main 서버와 다르게 실행할 수 있음

[NDD-424]: https://milk717.atlassian.net/browse/NDD-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ