### PR TITLE
[Hotfix] 버그픽스

### DIFF
--- a/src/video/dto/MemberVideoResponse.ts
+++ b/src/video/dto/MemberVideoResponse.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Video } from '../entity/video';
 import { createPropertyOption } from 'src/util/swagger.util';
 import { parseDateToString } from 'src/util/util';
+import { parseThumbnail } from '../util/video.util';
 
 export class MemberVideoResponse {
   @ApiProperty(createPropertyOption(1, '비디오 ID', Number))
@@ -60,7 +61,7 @@ export class MemberVideoResponse {
   public static from(video: Video) {
     return new MemberVideoResponse(
       video.id,
-      video.thumbnail,
+      parseThumbnail(video.thumbnail),
       video.name,
       video.videoLength,
       parseDateToString(video.createdAt),

--- a/src/video/dto/singleVideoResponse.ts
+++ b/src/video/dto/singleVideoResponse.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { createPropertyOption } from 'src/util/swagger.util';
 import { Video } from '../entity/video';
 import { parseDateToString } from 'src/util/util';
+import { parseThumbnail } from '../util/video.util';
 
 export class SingleVideoResponse {
   @ApiProperty(createPropertyOption(1, '비디오 ID', Number))
@@ -53,7 +54,7 @@ export class SingleVideoResponse {
   static from(video: Video) {
     return new SingleVideoResponse(
       video.id,
-      video.thumbnail,
+      parseThumbnail(video.thumbnail),
       video.name,
       video.videoLength,
       video.visibility,

--- a/src/video/dto/videoDetailResponse.ts
+++ b/src/video/dto/videoDetailResponse.ts
@@ -3,6 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { Member } from 'src/member/entity/member';
 import { createPropertyOption } from 'src/util/swagger.util';
 import { parseDateToString } from 'src/util/util';
+import { parseThumbnail } from '../util/video.util';
 
 export class VideoDetailResponse {
   @ApiProperty(createPropertyOption(1, '비디오의 ID', Number))
@@ -84,7 +85,7 @@ export class VideoDetailResponse {
       hash,
       parseDateToString(video.createdAt),
       video.visibility,
-      video.thumbnail,
+      parseThumbnail(video.thumbnail),
       video.videoAnswer.toString(),
     );
   }

--- a/src/video/service/video.service.spec.ts
+++ b/src/video/service/video.service.spec.ts
@@ -468,7 +468,7 @@ describe('VideoService 단위 테스트', () => {
       result.forEach((element) => {
         expect(element).toBeInstanceOf(SingleVideoResponse);
       });
-      expect(result[0].thumbnail).toBe(DEFAULT_THUMBNAIL);
+      expect(result[0].thumbnail).toBe('');
     });
 
     it('비디오 전체 조회 시 저장된 비디오가 없으면 빈 배열이 반환된다.', async () => {
@@ -1103,7 +1103,7 @@ describe('VideoService 통합 테스트', () => {
       // then
       expect(result).toHaveLength(1);
       expect(result[0]).toBeInstanceOf(SingleVideoResponse);
-      expect(result[0].thumbnail).toBe(video.thumbnail);
+      expect(result[0].thumbnail).toBe('');
       expect(result[0].videoName).toBe(video.name);
       expect(result[0].videoLength).toBe(video.videoLength);
       expect(result[0].visibility).toBe(video.visibility);

--- a/src/video/util/video.util.ts
+++ b/src/video/util/video.util.ts
@@ -1,0 +1,10 @@
+import { isEmpty } from 'class-validator';
+import { DEFAULT_THUMBNAIL } from 'src/constant/constant';
+
+export const parseThumbnail = (thumbnail: string): string => {
+  if (thumbnail === DEFAULT_THUMBNAIL || isEmpty(thumbnail)) {
+    return '';
+  }
+
+  return thumbnail;
+};

--- a/src/workbook/repository/workbook.repository.ts
+++ b/src/workbook/repository/workbook.repository.ts
@@ -47,7 +47,7 @@ export class WorkbookRepository {
     return this.repository
       .createQueryBuilder('Workbook')
       .where('Workbook.isPublic = :state', { state: true })
-      .andWhere('workbook.category = :categoryId', { categoryId })
+      .andWhere('Workbook.category = :categoryId', { categoryId })
       .orderBy('Workbook.copyCount', 'DESC')
       .getMany();
   }


### PR DESCRIPTION
# Why

1. 카테고리별 문제집 조회시 500에러 발생
    - 원인 : 쿼리문에서 `workbook.category`를 조회한다. 하지만 테이블은 Workbook으로 되어있다. 오타가 발생
    - 해결방안 : 오타 수정
2. 썸네일을 줄 때 저장된 썸네일이 없다면 빈 문자열을 줘야 함(프론트 요구사항)
    - 해결방안 : 기존의 데이터들이 있기 때문에, 유틸함수를 이용해 썸네일이 비어있거나 기본값이라면 빈 문자열을 주도록 구현함

# How

1번 이슈
- 디버깅(500에러에 대한 로그 확인)
<img width="831" alt="스크린샷 2024-04-17 15 36 44" src="https://github.com/the-NDD/Gomterview-BE/assets/99702271/5f9cf520-4c7a-42a6-8f8f-469d5bda9f4e">

우리의 테이블은 `Workbook`으로 되어있는데 쿼리에서 `workbook`이라는 테이블에서 컬럼을 조회한다. 
다른 부분은 이슈가 없지만 딱 저 where절에서 이슈가 발생했다. 

- 해결방식

<img width="471" alt="스크린샷 2024-04-17 15 35 51" src="https://github.com/the-NDD/Gomterview-BE/assets/99702271/ac676726-94be-4276-aca3-ff1612ec73ad">

쿼리에서 `workbook`을 `Workbook`으로 수정했다.

2번 이슈

- 해결 방식

<img width="527" alt="스크린샷 2024-04-17 15 38 08" src="https://github.com/the-NDD/Gomterview-BE/assets/99702271/344f8c00-de3c-42ca-9570-176bb84c36cb">

유틸함수를 만들어 thumbnail의 문자열이 DEFAULT_THUMBNAIL이거나 비어있으면 빈 문자열 반환하게 수정